### PR TITLE
fix: add missing env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 BASE_URL="base url for this website"
-NODE_ENV="environment"
+NODE_ENV="development or production"
+G_API_KEY="firebase api key"
+G_APP_ID="firebase app id"


### PR DESCRIPTION
Adds `NODE_ENV`, `G_API_KEY`, and `G_APP_ID` to `.env.example`. Without `NODE_ENV` set, the Firebase config falls into the production branch while using dev credentials, causing 400s on `webConfig` and `installations`.