### PR TITLE
fix: improve button contrast and sign out tap target size

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,9 +27,8 @@
       <v-spacer />
       <v-btn
         v-if="showSignOut"
-        variant="tonal"
+        variant="elevated"
         color="primary"
-        size="small"
         @click.stop="onSignoutClicked"
       >
         <v-icon start>mdi-logout</v-icon>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -73,6 +73,7 @@ export default defineNuxtConfig({
       defaults: {
         VBtn: {
           rounded: 'lg',
+          variant: 'elevated',
         },
         VCard: {
           rounded: 'xl',

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -6,10 +6,10 @@
           <v-icon color="primary" class="mr-3">mdi-account-circle</v-icon>
           <span class="page-title">Profile</span>
           <v-spacer />
-          <v-btn v-if="!editable && !loading" variant="tonal" color="primary" size="small" @click.stop="editable = true">
+          <v-btn v-if="!editable && !loading" variant="elevated" color="primary" size="small" @click.stop="editable = true">
             <v-icon start>mdi-pencil</v-icon>Edit
           </v-btn>
-          <v-btn v-if="editable" variant="tonal" color="success" size="small" @click.stop="updateProfile">
+          <v-btn v-if="editable" variant="elevated" color="success" size="small" @click.stop="updateProfile">
             <v-icon start>mdi-content-save</v-icon>Save
           </v-btn>
         </v-card-title>


### PR DESCRIPTION
Switches primary action buttons from `variant="tonal"` to `variant="elevated"` to resolve low contrast (blue text on blue-tinted background). Also removes `size="small"` from the sign out button to meet WCAG 2.5.5 minimum tap target guidelines.

**Changed files:**
- `layouts/default.vue` — sign out button: tonal → elevated, removed size=small
- `pages/profile.vue` — edit/save buttons: tonal → elevated  
- `nuxt.config.ts` — VBtn default variant set to elevated