### PR TITLE
fix: favicon href uses base URL prefix

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,8 +20,16 @@ export default defineNuxtConfig({
         },
       ],
       link: [
-        { rel: 'icon', type: 'image/png', href: '/favicon.png' },
-        { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
+        {
+          rel: 'icon',
+          type: 'image/png',
+          href: `${process.env.BASE_URL ?? '/'}favicon.png`,
+        },
+        {
+          rel: 'icon',
+          type: 'image/svg+xml',
+          href: `${process.env.BASE_URL ?? '/'}favicon.svg`,
+        },
         { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
         {
           rel: 'preconnect',


### PR DESCRIPTION
The favicon hrefs were hardcoded to `/favicon.png` and `/favicon.svg`, but the site is served under `/board-game-calendar/`. This caused a 404 since the browser looked for the favicon at the root path instead of the subpath. Updated the hrefs to prepend `BASE_URL` at build time.