### PR TITLE
fix: use absolute Firebase function URL for BGG proxy

### DIFF
--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -1,5 +1,7 @@
 export default {
-  BoardGameGeekBaseUrl: '/api/bgg/',
+  BoardGameGeekBaseUrl:
+    process.env.BGG_PROXY_URL ??
+    'https://us-central1-board-game-calendar-3ae94.cloudfunctions.net/bggProxy/',
   BggBoardGameType: 'boardgame',
   DebounceThrottleInMs: 500,
   NumberToShow: 10,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -120,6 +120,9 @@ export default defineNuxtConfig({
     define: {
       'process.env.G_API_KEY': JSON.stringify(process.env.G_API_KEY ?? ''),
       'process.env.G_APP_ID': JSON.stringify(process.env.G_APP_ID ?? ''),
+      'process.env.BGG_PROXY_URL': JSON.stringify(
+        process.env.BGG_PROXY_URL ?? ''
+      ),
     },
   },
 })


### PR DESCRIPTION
The relative `/api/bgg/` path resolved against GitHub Pages origin instead of the Firebase function. Switched to the absolute Firebase function URL with a `BGG_PROXY_URL` env var override for flexibility.