### PR TITLE
fix: preserve BGG_PROXY_URL fallback in constants

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -144,9 +144,7 @@ export default defineNuxtConfig({
     define: {
       'process.env.G_API_KEY': JSON.stringify(process.env.G_API_KEY ?? ''),
       'process.env.G_APP_ID': JSON.stringify(process.env.G_APP_ID ?? ''),
-      'process.env.BGG_PROXY_URL': JSON.stringify(
-        process.env.BGG_PROXY_URL ?? ''
-      ),
+      'process.env.BGG_PROXY_URL': JSON.stringify(process.env.BGG_PROXY_URL),
     },
   },
 })


### PR DESCRIPTION
When `BGG_PROXY_URL` is not set, `vite.define` was replacing it with an empty string. Since `??` in `constants.ts` only falls back for `null`/`undefined`, the hardcoded proxy URL was never used and `BoardGameGeekBaseUrl` ended up as `""`.\n\nFix: pass `process.env.BGG_PROXY_URL` directly without a fallback, so it injects `undefined` when unset and the fallback URL in `constants.ts` kicks in correctly.