### PR TITLE
fix: make bggProxy public with server-side origin enforcement

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,12 +15,15 @@ setGlobalOptions({
     'firebase-adminsdk-fbsvc@board-game-calendar-3ae94.iam.gserviceaccount.com',
 })
 
-export const bggProxy = onRequest(async (req, res) => {
+export const bggProxy = onRequest({ invoker: 'public' }, async (req, res) => {
   const origin = req.headers.origin ?? ''
 
-  if (ALLOWED_ORIGINS.includes(origin)) {
-    res.set('Access-Control-Allow-Origin', origin)
+  if (!ALLOWED_ORIGINS.includes(origin)) {
+    res.status(403).send('Forbidden')
+    return
   }
+
+  res.set('Access-Control-Allow-Origin', origin)
 
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {


### PR DESCRIPTION
The function was deployed without the `invoker: 'public'` option, causing a 401 for all requests. This also enforces the origin allowlist server-side (returning 403 for disallowed origins) rather than just using it for CORS headers.