### PR TITLE
fix: enforce bggProxy public invoker IAM binding after every deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,3 +54,12 @@ jobs:
           npx firebase-tools@latest deploy --only functions --project board-game-calendar-3ae94
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+
+      - name: Ensure bggProxy is publicly invokable
+        run: |
+          gcloud auth activate-service-account --key-file=/tmp/sa.json
+          gcloud run services add-iam-policy-binding bggproxy \
+            --region=us-central1 \
+            --member="allUsers" \
+            --role="roles/run.invoker" \
+            --project=board-game-calendar-3ae94


### PR DESCRIPTION
The `invoker: 'public'` option in the Firebase Functions v2 SDK doesn't reliably apply the Cloud Run IAM policy (likely due to org policy constraints). This adds a `gcloud` step after the Firebase deploy to explicitly bind `allUsers` to `roles/run.invoker` on every deploy, ensuring the function stays publicly accessible.