### PR TITLE
debug: add BGG request/response logging to bggProxy

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -45,7 +45,9 @@ export const bggProxy = onRequest({ invoker: 'public' }, async (req, res) => {
   ).toString()
   const url = `${BGG_BASE_URL}${bggPath}${queryString ? `?${queryString}` : ''}`
 
+  console.log(`Proxying request to BGG: ${url}`)
   const response = await fetch(url)
+  console.log(`BGG responded with status: ${response.status}`)
 
   if (!response.ok) {
     res.status(response.status).send(response.statusText)


### PR DESCRIPTION
Adds logging before and after the BGG fetch to confirm the URL being proxied and the status code returned by BGG.