### PR TITLE
feat(calendar): implement gatherings calendar and guest invitation flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,9 @@ typings/
 # nuxt.js build output
 .nuxt
 
-# Nuxt generate
+# Nuxt build/generate output
 dist
+.output
 
 # vuepress build output
 .vuepress/dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ Pre-commit hooks run `yarn lint` via husky + lint-staged. Commits must follow Co
 | `profile.vue`        | `/profile`        | `users/{uid}`                                       |
 | `gamecollection.vue` | `/gamecollection` | `users/{uid}/collection/{pushId}`                   |
 | `friends.vue`        | `/friends`        | `users/` (search), `users/{uid}/friends/{friendId}` |
-| `calendar.vue`       | `/calendar`       | `events` (host filter) — **stub, not MVP-complete** |
+| `calendar.vue`       | `/calendar`       | `gatherings` (loads all, splits into hosting/invited client-side), `users/{uid}/name` |
+| `gatherings/new.vue` | `/gatherings/new` | `gatherings/{pushId}` (create; `?id=` edits in place), `users/{uid}` (prefill) |
 | `index.vue`          | `/`               | none                                                |
 
 ### Key files
@@ -98,35 +99,17 @@ type Game = {
 }
 
 // users/{uid}/friends/{friendId}: true
-```
 
-### Defined but not yet used
-
-```ts
-type GatheringState = 'pending' | 'confirmed' | 'canceled' // not in types.ts yet
-
-// gatherings/{gatheringId}  — path does not exist yet
+// gatherings/{pushId}
 type Gathering = {
-  state: GatheringState
+  state: GatheringState // 'pending' | 'confirmed' | 'canceled'
   datetime: string // ISO date
   initiator: string // uid
   host: string // uid
   open: boolean
   maxGuests: number
-  guests: Guest[]
-  games: string[] // Game ids from host's collection
-}
-
-type Guest = {
-  id: string // uid
-  confirmed: boolean
-}
-
-// Calendar.vue currently uses this ad-hoc type instead:
-type EventType = {
-  host: string
-  date: Date
-  guests: Person[]
+  guests?: Record<string, GuestResponse> // keyed by uid; 'invited' | 'accepted' | 'declined'
+  games?: GatheringGame[] // { id, name } — denormalized from the host's collection
 }
 ```
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -13,7 +13,7 @@ Tasks are ordered by dependency — earlier items must be done before later ones
 - [x] Add `GatheringState` type: `'pending' | 'confirmed' | 'canceled'`
 - [x] Guest responses: instead of a `Guest[]` array, `guests` is a `Record<uid, GuestResponse>` (`'invited' | 'accepted' | 'declined'`) — keying by uid makes the security rule for "a guest may update only their own response" trivial, and the tri-state distinguishes "hasn't responded" from "declined"
 - [x] Add `Gathering` type — `games` is `GatheringGame[]` (`{ id, name }`), denormalized so guests can render game names without reading the host's collection
-- [ ] Remove the local `EventType` from `Calendar.vue` and replace with `Gathering`
+- [x] Remove the local `EventType` from `Calendar.vue` and replace with `Gathering`
 
 ---
 
@@ -46,25 +46,25 @@ Tasks are ordered by dependency — earlier items must be done before later ones
 
 ## 4. Calendar page — full implementation
 
-**`pages/Calendar.vue`** (currently a stub)
+**`pages/Calendar.vue`**
 
-- [ ] Replace `EventType` with `Gathering` type
-- [ ] Change Firebase query from `events` to `gatherings`, filtered to gatherings where `host === uid` OR `guests` contains `uid`
-- [ ] Display gathering state as a colored chip (pending = yellow, confirmed = green, canceled = red)
-- [ ] Display game list per gathering
-- [ ] Host actions: Edit, Cancel, Confirm (manual confirm for host)
-- [ ] Guest action: Accept / Decline button (writes to `guests[i].confirmed`)
-- [ ] Auto-confirm logic: transition to `confirmed` when all guests have responded (optional, can be host-only)
+- [x] Replace `EventType` with `Gathering` type
+- [x] Change Firebase query from `events` to `gatherings`, filtered to gatherings where `host === uid` OR `guests` contains `uid`
+- [x] Display gathering state as a colored chip (pending = yellow, confirmed = green, canceled = red)
+- [x] Display game list per gathering
+- [x] Host actions: Edit (reuses `/gatherings/new?id=`), Cancel, Confirm; Delete for canceled gatherings
+- [x] Guest action: Accept / Decline button (writes to `guests/{uid}`)
+- [ ] Auto-confirm logic: transition to `confirmed` when all guests have responded (optional — skipped; host confirms manually)
 
 ---
 
 ## 5. Guest invitation flow
 
-- [ ] When a gathering is created with specific guests, they need to see it
-  - Calendar query must include gatherings where the current user is in `guests[]`
-  - Firebase query: use `gatherings` index on `guests/{uid}` or load all gatherings and filter client-side (simpler for MVP)
-- [ ] Show "Invited" gatherings separately from "Hosting" gatherings on the calendar
-- [ ] Accept / Decline updates `gatherings/{id}/guests/{i}/confirmed`
+- [x] When a gathering is created with specific guests, they need to see it
+  - Calendar query must include gatherings where the current user is in `guests`
+  - Firebase query: load all gatherings and filter client-side (simpler for MVP)
+- [x] Show "Invited" gatherings separately from "Hosting" gatherings on the calendar
+- [x] Accept / Decline updates `gatherings/{id}/guests/{uid}`
 
 ---
 
@@ -72,7 +72,7 @@ Tasks are ordered by dependency — earlier items must be done before later ones
 
 **`.github/workflows/ci.yml`**
 
-- [ ] Uncomment (or re-add) the `yarn test` step — it was commented out and the test suite is now passing
+- [x] Uncomment (or re-add) the `yarn test` step — it was commented out and the test suite is now passing
 
 ---
 

--- a/helpers/gatherings.ts
+++ b/helpers/gatherings.ts
@@ -1,0 +1,74 @@
+import type { Gathering, GatheringState, GuestResponse } from './types'
+
+export type GatheringWithId = Gathering & { id: string }
+
+const byDatetime = (a: GatheringWithId, b: GatheringWithId) =>
+  a.datetime.localeCompare(b.datetime)
+
+// Rules are not filters: any signed-in user may read gatherings, so the
+// calendar loads them all and splits them client-side (MVP approach)
+export function splitGatherings(
+  gatherings: GatheringWithId[],
+  uid: string,
+  now: number = Date.now()
+) {
+  return {
+    hosting: gatherings.filter((g) => g.host === uid).sort(byDatetime),
+    invited: gatherings
+      .filter((g) => g.host !== uid && g.guests?.[uid])
+      .sort(byDatetime),
+    open: gatherings
+      .filter(
+        (g) =>
+          g.host !== uid &&
+          !g.guests?.[uid] &&
+          g.open &&
+          g.state !== 'canceled' &&
+          new Date(g.datetime).getTime() > now
+      )
+      .sort(byDatetime),
+  }
+}
+
+export function acceptedCount(gathering: Gathering): number {
+  return Object.values(gathering.guests ?? {}).filter(
+    (response) => response === 'accepted'
+  ).length
+}
+
+export function isFull(gathering: Gathering): boolean {
+  return gathering.maxGuests > 0 && acceptedCount(gathering) >= gathering.maxGuests
+}
+
+export function stateColor(state: GatheringState): string {
+  return (
+    { pending: 'warning', confirmed: 'success', canceled: 'error' }[state] ??
+    'info'
+  )
+}
+
+export function responseColor(response: GuestResponse): string {
+  return (
+    { invited: 'warning', accepted: 'success', declined: 'error' }[response] ??
+    'info'
+  )
+}
+
+export function responseIcon(response: GuestResponse): string {
+  return (
+    {
+      invited: 'mdi-help-circle-outline',
+      accepted: 'mdi-check-circle-outline',
+      declined: 'mdi-close-circle-outline',
+    }[response] ?? 'mdi-help-circle-outline'
+  )
+}
+
+export function formatDatetime(iso: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -14,7 +14,7 @@
         <v-card-text v-if="loading" class="pa-8">
           <v-progress-linear indeterminate color="primary" />
         </v-card-text>
-        <v-card-text v-else-if="!hosting.length && !invited.length" class="pa-6">
+        <v-card-text v-else-if="!hosting.length && !invited.length && !openGatherings.length" class="pa-6">
           <div class="empty-state">
             <v-icon size="64" color="primary" class="mb-4" style="opacity: 0.3">mdi-calendar-blank-outline</v-icon>
             <div class="empty-title">No gatherings yet</div>
@@ -61,8 +61,32 @@
             </div>
           </template>
 
+          <template v-if="openGatherings.length">
+            <div class="section-title mb-3" :class="{ 'mt-4': hosting.length }">Open gatherings</div>
+            <div v-for="gathering in openGatherings" :key="gathering.id" class="event-item pa-4 mb-3">
+              <div class="d-flex align-center flex-wrap mb-2">
+                <v-chip :color="stateColor(gathering.state)" size="small" variant="tonal" class="mr-2 text-capitalize">{{ gathering.state }}</v-chip>
+                <span class="event-line"><v-icon size="16" class="mr-1">mdi-clock-outline</v-icon>{{ formatDatetime(gathering.datetime) }}</span>
+                <v-spacer />
+                <v-btn density="compact" size="small" variant="tonal" color="success" :disabled="isFull(gathering)" @click.stop="respond(gathering, 'accepted')">
+                  <v-icon start>mdi-account-plus</v-icon>{{ isFull(gathering) ? 'Full' : 'Join' }}
+                </v-btn>
+              </div>
+              <div class="event-line mb-2">
+                <v-icon size="16" class="mr-1">mdi-account</v-icon>Hosted by {{ names[gathering.host] ?? '…' }}
+                <template v-if="gathering.maxGuests > 0">
+                  <span class="mx-2">·</span>{{ acceptedCount(gathering) }}/{{ gathering.maxGuests }} guests
+                </template>
+              </div>
+              <div v-if="gathering.games?.length" class="event-line">
+                <v-icon size="16" class="mr-1">mdi-rhombus-split</v-icon>
+                <v-chip v-for="game in gathering.games" :key="game.id" size="x-small" variant="outlined" class="mr-1">{{ game.name }}</v-chip>
+              </div>
+            </div>
+          </template>
+
           <template v-if="invited.length">
-            <div class="section-title mb-3" :class="{ 'mt-4': hosting.length }">Invited</div>
+            <div class="section-title mb-3" :class="{ 'mt-4': hosting.length || openGatherings.length }">Invited</div>
             <div v-for="gathering in invited" :key="gathering.id" class="event-item pa-4 mb-3">
               <div class="d-flex align-center flex-wrap mb-2">
                 <v-chip :color="stateColor(gathering.state)" size="small" variant="tonal" class="mr-2 text-capitalize">{{ gathering.state }}</v-chip>
@@ -99,11 +123,19 @@ import Snackbar from '~/components/Snackbar.vue'
 import helpers from '~/helpers/helpers'
 import routes from '~/helpers/routes'
 import constants from '~/helpers/constants'
+import {
+  splitGatherings,
+  acceptedCount,
+  isFull,
+  stateColor,
+  responseColor,
+  responseIcon,
+  formatDatetime,
+  type GatheringWithId,
+} from '~/helpers/gatherings'
 import type { Gathering, GatheringState, GuestResponse } from '~/helpers/types'
 
 useHead({ title: 'Calendar' })
-
-type GatheringWithId = Gathering & { id: string }
 
 const userStore = useUserStore()
 const router = useRouter()
@@ -135,17 +167,15 @@ onMounted(() => {
 
 onUnmounted(() => { unsubscribe?.() })
 
-const byDatetime = (a: GatheringWithId, b: GatheringWithId) => a.datetime.localeCompare(b.datetime)
-
-const hosting = computed(() => gatherings.value.filter((g) => g.host === uid).sort(byDatetime))
-const invited = computed(() => gatherings.value.filter((g) => g.host !== uid && g.guests?.[uid]).sort(byDatetime))
+const sections = computed(() => splitGatherings(gatherings.value, uid))
+const hosting = computed(() => sections.value.hosting)
+const invited = computed(() => sections.value.invited)
+const openGatherings = computed(() => sections.value.open)
 
 async function resolveNames() {
   const wanted = new Set<string>()
-  for (const gathering of gatherings.value) {
-    if (gathering.host === uid) Object.keys(gathering.guests ?? {}).forEach((guestUid) => wanted.add(guestUid))
-    else if (gathering.guests?.[uid]) wanted.add(gathering.host)
-  }
+  for (const gathering of sections.value.hosting) Object.keys(gathering.guests ?? {}).forEach((guestUid) => wanted.add(guestUid))
+  for (const gathering of [...sections.value.invited, ...sections.value.open]) wanted.add(gathering.host)
   const missing = [...wanted].filter((personUid) => !(personUid in names.value))
   await Promise.all(missing.map(async (personUid) => {
     try {
@@ -163,28 +193,6 @@ function guestEntries(gathering: Gathering): { uid: string; response: GuestRespo
 
 function myResponse(gathering: Gathering): GuestResponse | undefined {
   return gathering.guests?.[uid]
-}
-
-function stateColor(state: GatheringState): string {
-  return { pending: 'warning', confirmed: 'success', canceled: 'error' }[state] ?? 'info'
-}
-
-function responseColor(response: GuestResponse): string {
-  return { invited: 'warning', accepted: 'success', declined: 'error' }[response] ?? 'info'
-}
-
-function responseIcon(response: GuestResponse): string {
-  return {
-    invited: 'mdi-help-circle-outline',
-    accepted: 'mdi-check-circle-outline',
-    declined: 'mdi-close-circle-outline',
-  }[response] ?? 'mdi-help-circle-outline'
-}
-
-function formatDatetime(iso: string): string {
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return iso
-  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
 }
 
 async function setState(gathering: GatheringWithId, state: GatheringState) {

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -4,70 +4,216 @@
       <v-card>
         <v-card-title class="d-flex align-center pa-6">
           <v-icon color="primary" class="mr-3">mdi-calendar</v-icon>
-          <span class="page-title">Calendar Events</span>
+          <span class="page-title">Calendar</span>
+          <v-spacer />
+          <v-btn variant="elevated" color="primary" size="small" :to="routes.newGathering">
+            <v-icon start>mdi-calendar-plus</v-icon>New
+          </v-btn>
         </v-card-title>
         <v-divider />
         <v-card-text v-if="loading" class="pa-8">
           <v-progress-linear indeterminate color="primary" />
         </v-card-text>
-        <v-card-text v-else-if="!events.length" class="pa-6">
+        <v-card-text v-else-if="!hosting.length && !invited.length" class="pa-6">
           <div class="empty-state">
             <v-icon size="64" color="primary" class="mb-4" style="opacity: 0.3">mdi-calendar-blank-outline</v-icon>
-            <div class="empty-title">No events yet</div>
-            <div class="empty-desc">Your upcoming game nights will appear here.</div>
+            <div class="empty-title">No gatherings yet</div>
+            <div class="empty-desc">Host a game night or get invited to one, and it will show up here.</div>
+            <v-btn variant="elevated" color="primary" class="mt-4" :to="routes.newGathering">
+              <v-icon start>mdi-calendar-plus</v-icon>New Gathering
+            </v-btn>
           </div>
         </v-card-text>
         <v-card-text v-else class="pa-6">
-          <div v-for="(event, i) in events" :key="i" class="event-item pa-4 mb-3">
-            <div class="event-host mb-1"><v-icon size="16" class="mr-2">mdi-account</v-icon>Host: {{ event.host }}</div>
-            <div class="event-date mb-1"><v-icon size="16" class="mr-2">mdi-calendar</v-icon>Date: {{ event.date }}</div>
-            <div class="event-guests"><v-icon size="16" class="mr-2">mdi-account-group</v-icon>Guests: {{ event.guests && event.guests.map((guest) => guest.name) }}</div>
-          </div>
+          <template v-if="hosting.length">
+            <div class="section-title mb-3">Hosting</div>
+            <div v-for="gathering in hosting" :key="gathering.id" class="event-item pa-4 mb-3">
+              <div class="d-flex align-center flex-wrap mb-2">
+                <v-chip :color="stateColor(gathering.state)" size="small" variant="tonal" class="mr-2 text-capitalize">{{ gathering.state }}</v-chip>
+                <span class="event-line"><v-icon size="16" class="mr-1">mdi-clock-outline</v-icon>{{ formatDatetime(gathering.datetime) }}</span>
+                <v-spacer />
+                <v-btn v-if="gathering.state === 'pending'" density="compact" size="small" variant="text" color="success" @click.stop="setState(gathering, 'confirmed')">
+                  <v-icon start>mdi-check-circle</v-icon>Confirm
+                </v-btn>
+                <v-btn v-if="gathering.state !== 'canceled'" density="compact" size="small" variant="text" color="accent" @click.stop="editGathering(gathering)">
+                  <v-icon start>mdi-pencil</v-icon>Edit
+                </v-btn>
+                <v-btn v-if="gathering.state !== 'canceled'" density="compact" size="small" variant="text" color="error" @click.stop="setState(gathering, 'canceled')">
+                  <v-icon start>mdi-cancel</v-icon>Cancel
+                </v-btn>
+                <v-btn v-else density="compact" size="small" variant="text" color="error" @click.stop="deleteGathering(gathering)">
+                  <v-icon start>mdi-delete</v-icon>Delete
+                </v-btn>
+              </div>
+              <div v-if="gathering.games?.length" class="event-line mb-2">
+                <v-icon size="16" class="mr-1">mdi-rhombus-split</v-icon>
+                <v-chip v-for="game in gathering.games" :key="game.id" size="x-small" variant="outlined" class="mr-1">{{ game.name }}</v-chip>
+              </div>
+              <div v-if="guestEntries(gathering).length" class="event-line">
+                <v-icon size="16" class="mr-1">mdi-account-group</v-icon>
+                <v-chip v-for="guest in guestEntries(gathering)" :key="guest.uid" size="x-small" :color="responseColor(guest.response)" variant="tonal" class="mr-1">
+                  <v-icon start size="12">{{ responseIcon(guest.response) }}</v-icon>{{ names[guest.uid] ?? '…' }}
+                </v-chip>
+              </div>
+              <div v-else class="event-line">
+                <v-icon size="16" class="mr-1">mdi-account-group</v-icon>No guests invited yet
+              </div>
+            </div>
+          </template>
+
+          <template v-if="invited.length">
+            <div class="section-title mb-3" :class="{ 'mt-4': hosting.length }">Invited</div>
+            <div v-for="gathering in invited" :key="gathering.id" class="event-item pa-4 mb-3">
+              <div class="d-flex align-center flex-wrap mb-2">
+                <v-chip :color="stateColor(gathering.state)" size="small" variant="tonal" class="mr-2 text-capitalize">{{ gathering.state }}</v-chip>
+                <span class="event-line"><v-icon size="16" class="mr-1">mdi-clock-outline</v-icon>{{ formatDatetime(gathering.datetime) }}</span>
+              </div>
+              <div class="event-line mb-2">
+                <v-icon size="16" class="mr-1">mdi-account</v-icon>Hosted by {{ names[gathering.host] ?? '…' }}
+              </div>
+              <div v-if="gathering.games?.length" class="event-line mb-2">
+                <v-icon size="16" class="mr-1">mdi-rhombus-split</v-icon>
+                <v-chip v-for="game in gathering.games" :key="game.id" size="x-small" variant="outlined" class="mr-1">{{ game.name }}</v-chip>
+              </div>
+              <div v-if="gathering.state !== 'canceled'" class="d-flex align-center mt-1">
+                <v-btn density="compact" size="small" :variant="myResponse(gathering) === 'accepted' ? 'tonal' : 'text'" color="success" class="mr-2" @click.stop="respond(gathering, 'accepted')">
+                  <v-icon start>mdi-check-circle</v-icon>Accept
+                </v-btn>
+                <v-btn density="compact" size="small" :variant="myResponse(gathering) === 'declined' ? 'tonal' : 'text'" color="error" @click.stop="respond(gathering, 'declined')">
+                  <v-icon start>mdi-close-circle</v-icon>Decline
+                </v-btn>
+              </div>
+            </div>
+          </template>
         </v-card-text>
       </v-card>
+      <Snackbar ref="snackbar" />
     </v-col>
   </v-row>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
-import {
-  ref as dbRef,
-  query,
-  orderByChild,
-  equalTo,
-  onValue,
-} from 'firebase/database'
-import type { Person } from '~/helpers/types'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref as dbRef, onValue, get, update, set, remove } from 'firebase/database'
+import Snackbar from '~/components/Snackbar.vue'
+import helpers from '~/helpers/helpers'
+import routes from '~/helpers/routes'
 import constants from '~/helpers/constants'
+import type { Gathering, GatheringState, GuestResponse } from '~/helpers/types'
 
 useHead({ title: 'Calendar' })
 
-type EventType = { host: string; date: Date; guests: Person[] }
+type GatheringWithId = Gathering & { id: string }
 
 const userStore = useUserStore()
-const events = ref<EventType[]>([])
-const loading = ref(true)
-let unsubscribe: (() => void) | null = null
-
+const router = useRouter()
 const nuxtApp = useNuxtApp()
 const db = nuxtApp.$db
 
+const snackbar = ref<InstanceType<typeof Snackbar> | null>(null)
+const gatherings = ref<GatheringWithId[]>([])
+const names = ref<Record<string, string>>({})
+const loading = ref(true)
+let unsubscribe: (() => void) | null = null
+
+const uid = userStore.user!.uid
+
 onMounted(() => {
-  const q = query(dbRef(db, 'events'), orderByChild('host'), equalTo(userStore.user!.uid))
-  unsubscribe = onValue(q, (snapshot) => { const val = snapshot.val(); loading.value = false; events.value = val ? Object.values(val) : [] })
+  // Rules are not filters: any signed-in user may read gatherings, so load
+  // them all and split into hosting/invited client-side (MVP approach)
+  unsubscribe = onValue(dbRef(db, 'gatherings'), (snapshot) => {
+    const val = snapshot.val() as Record<string, Gathering> | null
+    loading.value = false
+    gatherings.value = val ? Object.entries(val).map(([id, gathering]) => ({ id, ...gathering })) : []
+    void resolveNames()
+  }, (err) => {
+    loading.value = false
+    snackbar.value?.showSnackbarWithMessage(helpers.handleError(err).message, true)
+  })
   setTimeout(() => { loading.value = false }, constants.LoadingTimeoutInMs)
 })
 
 onUnmounted(() => { unsubscribe?.() })
+
+const byDatetime = (a: GatheringWithId, b: GatheringWithId) => a.datetime.localeCompare(b.datetime)
+
+const hosting = computed(() => gatherings.value.filter((g) => g.host === uid).sort(byDatetime))
+const invited = computed(() => gatherings.value.filter((g) => g.host !== uid && g.guests?.[uid]).sort(byDatetime))
+
+async function resolveNames() {
+  const wanted = new Set<string>()
+  for (const gathering of gatherings.value) {
+    if (gathering.host === uid) Object.keys(gathering.guests ?? {}).forEach((guestUid) => wanted.add(guestUid))
+    else if (gathering.guests?.[uid]) wanted.add(gathering.host)
+  }
+  const missing = [...wanted].filter((personUid) => !(personUid in names.value))
+  await Promise.all(missing.map(async (personUid) => {
+    try {
+      const snap = await get(dbRef(db, `users/${personUid}/name`))
+      names.value[personUid] = snap.val() ?? 'Unknown player'
+    } catch {
+      names.value[personUid] = 'Unknown player'
+    }
+  }))
+}
+
+function guestEntries(gathering: Gathering): { uid: string; response: GuestResponse }[] {
+  return Object.entries(gathering.guests ?? {}).map(([guestUid, response]) => ({ uid: guestUid, response }))
+}
+
+function myResponse(gathering: Gathering): GuestResponse | undefined {
+  return gathering.guests?.[uid]
+}
+
+function stateColor(state: GatheringState): string {
+  return { pending: 'warning', confirmed: 'success', canceled: 'error' }[state] ?? 'info'
+}
+
+function responseColor(response: GuestResponse): string {
+  return { invited: 'warning', accepted: 'success', declined: 'error' }[response] ?? 'info'
+}
+
+function responseIcon(response: GuestResponse): string {
+  return {
+    invited: 'mdi-help-circle-outline',
+    accepted: 'mdi-check-circle-outline',
+    declined: 'mdi-close-circle-outline',
+  }[response] ?? 'mdi-help-circle-outline'
+}
+
+function formatDatetime(iso: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+async function setState(gathering: GatheringWithId, state: GatheringState) {
+  try { await update(dbRef(db, `gatherings/${gathering.id}`), { state }) }
+  catch (err) { snackbar.value?.showSnackbarWithMessage(helpers.handleError(err).message, true) }
+}
+
+async function respond(gathering: GatheringWithId, response: GuestResponse) {
+  try { await set(dbRef(db, `gatherings/${gathering.id}/guests/${uid}`), response) }
+  catch (err) { snackbar.value?.showSnackbarWithMessage(helpers.handleError(err).message, true) }
+}
+
+async function deleteGathering(gathering: GatheringWithId) {
+  try { await remove(dbRef(db, `gatherings/${gathering.id}`)) }
+  catch (err) { snackbar.value?.showSnackbarWithMessage(helpers.handleError(err).message, true) }
+}
+
+function editGathering(gathering: GatheringWithId) {
+  router.push({ path: routes.newGathering, query: { id: gathering.id } })
+}
 </script>
 
 <style scoped>
 .page-title { font-size: 1.25rem; font-weight: 600; }
+.section-title { font-size: 0.8rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: rgba(205,214,244,0.5); }
 .empty-state { text-align: center; padding: 48px 24px; }
 .empty-title { font-size: 1.1rem; font-weight: 600; color: rgba(205,214,244,0.7); }
 .empty-desc { font-size: 0.85rem; color: rgba(205,214,244,0.4); margin-top: 4px; }
 .event-item { border-radius: 12px; background: rgba(108,92,231,0.04); border: 1px solid rgba(108,92,231,0.08); transition: all 0.2s ease; }
 .event-item:hover { background: rgba(108,92,231,0.08); border-color: rgba(108,92,231,0.15); }
-.event-host, .event-date, .event-guests { font-size: 0.9rem; color: rgba(205,214,244,0.8); display: flex; align-items: center; }
+.event-line { font-size: 0.9rem; color: rgba(205,214,244,0.8); display: inline-flex; align-items: center; flex-wrap: wrap; }
 </style>

--- a/pages/gatherings/new.vue
+++ b/pages/gatherings/new.vue
@@ -43,8 +43,6 @@ import helpers from '~/helpers/helpers'
 import routes from '~/helpers/routes'
 import type { FormInstance, Game, Gathering, GatheringState, GuestResponse } from '~/helpers/types'
 
-useHead({ title: 'New Gathering' })
-
 const userStore = useUserStore()
 const router = useRouter()
 const route = useRoute()
@@ -71,6 +69,8 @@ let gamesById: Record<string, Game> = {}
 const editId = typeof route.query.id === 'string' ? route.query.id : null
 let existingState: GatheringState = 'pending'
 let existingGuests: Record<string, GuestResponse> = {}
+
+useHead({ title: editId ? 'Edit Gathering' : 'New Gathering' })
 
 const validation = {
   isRequired: (v: string) => !!v || 'Required',

--- a/pages/gatherings/new.vue
+++ b/pages/gatherings/new.vue
@@ -3,8 +3,8 @@
     <v-col cols="12" sm="11" md="9" lg="6">
       <v-card>
         <v-card-title class="d-flex align-center pa-6">
-          <v-icon color="primary" class="mr-3">mdi-calendar-plus</v-icon>
-          <span class="page-title">New Gathering</span>
+          <v-icon color="primary" class="mr-3">{{ editId ? 'mdi-calendar-edit' : 'mdi-calendar-plus' }}</v-icon>
+          <span class="page-title">{{ editId ? 'Edit Gathering' : 'New Gathering' }}</span>
         </v-card-title>
         <v-divider />
         <v-card-text v-if="loading" class="pa-8">
@@ -25,7 +25,7 @@
             <v-select v-model="selectedGuests" :items="friendItems" multiple chips closable-chips label="Invite friends" prepend-inner-icon="mdi-account-group" :hint="friendItems.length ? '' : 'Add friends on the Friends page to invite them'" persistent-hint class="mb-1" />
             <v-select v-model="selectedGameIds" :items="gameItems" multiple chips closable-chips label="Games to play" prepend-inner-icon="mdi-rhombus-split" :hint="gameItems.length ? '' : 'Add games on the Game Collection page to pick them'" persistent-hint class="mb-4" />
             <v-btn type="submit" block color="primary" size="large" :loading="saving">
-              <v-icon start>mdi-calendar-check</v-icon>Create Gathering
+              <v-icon start>mdi-calendar-check</v-icon>{{ editId ? 'Save Changes' : 'Create Gathering' }}
             </v-btn>
           </v-form>
         </v-card-text>
@@ -37,16 +37,17 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { ref as dbRef, get, push, set } from 'firebase/database'
+import { ref as dbRef, get, push, set, update } from 'firebase/database'
 import Snackbar from '~/components/Snackbar.vue'
 import helpers from '~/helpers/helpers'
 import routes from '~/helpers/routes'
-import type { FormInstance, Game, Gathering, GuestResponse } from '~/helpers/types'
+import type { FormInstance, Game, Gathering, GatheringState, GuestResponse } from '~/helpers/types'
 
 useHead({ title: 'New Gathering' })
 
 const userStore = useUserStore()
 const router = useRouter()
+const route = useRoute()
 const nuxtApp = useNuxtApp()
 const db = nuxtApp.$db
 const logEvent = nuxtApp.$logEvent
@@ -65,6 +66,11 @@ const selectedGameIds = ref<string[]>([])
 const friendItems = ref<{ title: string; value: string }[]>([])
 const gameItems = ref<{ title: string; value: string }[]>([])
 let gamesById: Record<string, Game> = {}
+
+// Edit mode: /gatherings/new?id={gatheringId} prefills and updates in place
+const editId = typeof route.query.id === 'string' ? route.query.id : null
+let existingState: GatheringState = 'pending'
+let existingGuests: Record<string, GuestResponse> = {}
 
 const validation = {
   isRequired: (v: string) => !!v || 'Required',
@@ -102,6 +108,40 @@ onMounted(async () => {
         .map((game) => ({ title: game.name, value: game.id }))
         .sort((a, b) => a.title.localeCompare(b.title))
     }
+
+    if (editId) {
+      const gatheringSnap = await get(dbRef(db, `gatherings/${editId}`))
+      const gathering: Gathering | null = gatheringSnap.val()
+      if (!gathering || gathering.host !== uid) {
+        snackbar.value?.showSnackbarWithMessage('Gathering not found.', true)
+        await router.replace(routes.calendar)
+        return
+      }
+      existingState = gathering.state
+      existingGuests = gathering.guests ?? {}
+      const dt = new Date(gathering.datetime)
+      const pad = (n: number) => String(n).padStart(2, '0')
+      date.value = `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}`
+      time.value = `${pad(dt.getHours())}:${pad(dt.getMinutes())}`
+      maxGuests.value = gathering.maxGuests
+      open.value = gathering.open
+      selectedGuests.value = Object.keys(existingGuests)
+      selectedGameIds.value = (gathering.games ?? []).map((game) => game.id)
+      // Keep invited guests visible even if they are no longer friends
+      for (const guestId of selectedGuests.value) {
+        if (!friendItems.value.some((friend) => friend.value === guestId)) {
+          const nameSnap = await get(dbRef(db, `users/${guestId}/name`))
+          friendItems.value.push({ title: nameSnap.val() ?? 'Unknown player', value: guestId })
+        }
+      }
+      // Keep selections visible even if a game has since left the collection
+      for (const game of gathering.games ?? []) {
+        if (!gamesById[game.id]) {
+          gamesById[game.id] = game
+          gameItems.value.push({ title: game.name, value: game.id })
+        }
+      }
+    }
   } catch (err) {
     snackbar.value?.showSnackbarWithMessage(helpers.handleError(err).message, true)
   } finally {
@@ -125,17 +165,22 @@ async function createGathering() {
   try {
     const uid = userStore.user!.uid
     const gathering: Gathering = {
-      state: 'pending',
+      state: editId ? existingState : 'pending',
       datetime: datetime.toISOString(),
       initiator: uid,
       host: uid,
       open: open.value,
       maxGuests: Number(maxGuests.value || 0),
-      guests: Object.fromEntries(selectedGuests.value.map((guestId) => [guestId, 'invited' as GuestResponse])),
+      // existing guests keep their response when editing; new ones start as invited
+      guests: Object.fromEntries(selectedGuests.value.map((guestId) => [guestId, existingGuests[guestId] ?? ('invited' as GuestResponse)])),
       games: selectedGameIds.value.map((id) => ({ id, name: gamesById[id]?.name ?? 'Unknown game' })),
     }
-    await set(push(dbRef(db, 'gatherings')), gathering)
-    logEvent('create_gathering', { guests: selectedGuests.value.length, games: selectedGameIds.value.length })
+    if (editId) {
+      await update(dbRef(db, `gatherings/${editId}`), gathering)
+    } else {
+      await set(push(dbRef(db, 'gatherings')), gathering)
+    }
+    logEvent(editId ? 'edit_gathering' : 'create_gathering', { guests: selectedGuests.value.length, games: selectedGameIds.value.length })
     await router.push(routes.calendar)
   } catch (err) {
     snackbar.value?.showSnackbarWithMessage(helpers.handleError(err).message, true)

--- a/test/gatherings.spec.ts
+++ b/test/gatherings.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import {
+  splitGatherings,
+  acceptedCount,
+  isFull,
+  stateColor,
+  type GatheringWithId,
+} from '~/helpers/gatherings'
+import type { Gathering } from '~/helpers/types'
+
+const NOW = new Date('2026-06-01T12:00:00Z').getTime()
+const FUTURE = '2026-07-01T19:00:00.000Z'
+const PAST = '2026-05-01T19:00:00.000Z'
+
+function gathering(overrides: Partial<GatheringWithId>): GatheringWithId {
+  return {
+    id: 'g',
+    state: 'pending',
+    datetime: FUTURE,
+    initiator: 'host1',
+    host: 'host1',
+    open: false,
+    maxGuests: 4,
+    ...overrides,
+  }
+}
+
+describe('splitGatherings', () => {
+  it('splits into hosting, invited, and open sections', () => {
+    const all = [
+      gathering({ id: 'mine', host: 'me' }),
+      gathering({ id: 'inv', guests: { me: 'invited' } }),
+      gathering({ id: 'open', open: true }),
+      gathering({ id: 'closed' }),
+    ]
+    const { hosting, invited, open } = splitGatherings(all, 'me', NOW)
+    expect(hosting.map((g) => g.id)).toEqual(['mine'])
+    expect(invited.map((g) => g.id)).toEqual(['inv'])
+    expect(open.map((g) => g.id)).toEqual(['open'])
+  })
+
+  it('does not list my own or already-joined gatherings as open', () => {
+    const all = [
+      gathering({ id: 'mine', host: 'me', open: true }),
+      gathering({ id: 'joined', open: true, guests: { me: 'accepted' } }),
+    ]
+    const { invited, open } = splitGatherings(all, 'me', NOW)
+    expect(open).toEqual([])
+    expect(invited.map((g) => g.id)).toEqual(['joined'])
+  })
+
+  it('hides past and canceled gatherings from the open section only', () => {
+    const all = [
+      gathering({ id: 'past', open: true, datetime: PAST }),
+      gathering({ id: 'canceled', open: true, state: 'canceled' }),
+      gathering({
+        id: 'pastInvite',
+        datetime: PAST,
+        guests: { me: 'invited' },
+      }),
+    ]
+    const { invited, open } = splitGatherings(all, 'me', NOW)
+    expect(open).toEqual([])
+    expect(invited.map((g) => g.id)).toEqual(['pastInvite'])
+  })
+
+  it('sorts each section by datetime ascending', () => {
+    const all = [
+      gathering({ id: 'later', host: 'me', datetime: '2026-08-01T19:00:00.000Z' }),
+      gathering({ id: 'sooner', host: 'me', datetime: FUTURE }),
+    ]
+    expect(splitGatherings(all, 'me', NOW).hosting.map((g) => g.id)).toEqual([
+      'sooner',
+      'later',
+    ])
+  })
+})
+
+describe('capacity helpers', () => {
+  const guests: Gathering['guests'] = {
+    a: 'accepted',
+    b: 'accepted',
+    c: 'declined',
+    d: 'invited',
+  }
+
+  it('counts only accepted guests', () => {
+    expect(acceptedCount(gathering({ guests }))).toBe(2)
+    expect(acceptedCount(gathering({}))).toBe(0)
+  })
+
+  it('reports fullness against maxGuests', () => {
+    expect(isFull(gathering({ guests, maxGuests: 2 }))).toBe(true)
+    expect(isFull(gathering({ guests, maxGuests: 3 }))).toBe(false)
+    // maxGuests 0 means "no limit set"
+    expect(isFull(gathering({ guests, maxGuests: 0 }))).toBe(false)
+  })
+})
+
+describe('stateColor', () => {
+  it('maps states to theme colors', () => {
+    expect(stateColor('pending')).toBe('warning')
+    expect(stateColor('confirmed')).toBe('success')
+    expect(stateColor('canceled')).toBe('error')
+  })
+})


### PR DESCRIPTION
## Gathering MVP — PR 4 of 4 (stacked on #420 ← #419 ← #418)

Completes TASKS.md §4 (calendar) and §5 (guest invitation flow). With this PR the MVP loop works end-to-end: build a collection → add friends → create a gathering around specific games → guests accept/decline (or join open gatherings) → host confirms.

### Calendar (`/calendar`, was a stub querying a nonexistent `events` path)

- Subscribes to `gatherings` and splits client-side into **Hosting**, **Open gatherings**, and **Invited** sections (per the TASKS.md MVP plan; the rules from #418 allow any authenticated user to read gatherings)
- State shown as a colored chip — pending = warning, confirmed = success, canceled = error
- Game list rendered as chips from the denormalized `games` array
- Host view: per-guest response chips (name + invited/accepted/declined), plus **Confirm** (when pending), **Edit**, **Cancel**, and **Delete** (canceled gatherings only)
- Guest view: host name, games, and **Accept / Decline** buttons that write `gatherings/{id}/guests/{uid}` — the only write the rules permit a guest
- **Open gatherings**: upcoming open gatherings the user isn't part of are listed with host, accepted-guest count, and a **Join** button (disabled with a "Full" label once accepted guests reach `maxGuests`; capacity is client-side only — see #418 notes). Joining writes the user's own `accepted` entry, which the #418 rules permit for open, non-canceled gatherings.
- Player names resolved once into a cache from `users/{uid}/name`
- The splitting/capacity/chip logic lives in `helpers/gatherings.ts` with **unit tests** (sections, past/canceled exclusion, sort order, accepted counting, fullness)

### Edit mode for the gathering form

`/gatherings/new?id={gatheringId}` prefills the form and updates in place. Gathering `state` and existing guest responses are preserved; newly added guests start as `invited`; removed guests are dropped. Games/guests that have since left the host's collection/friends list are backfilled so the selections stay visible. Non-hosts are bounced back to the calendar.

### Skipped (documented in TASKS.md)

- Auto-confirm when all guests respond — marked optional in TASKS.md; the host's manual Confirm covers it.
- §7 game notes — explicitly post-MVP.

### Verification

- `yarn lint` and `yarn test` pass (11 unit tests)
- `yarn test:rules` — 13/13 security-rules tests against the RTDB emulator
- `yarn generate` production build succeeds with all 10 routes prerendered, including `/gatherings/new`

https://claude.ai/code/session_014r58WyDwDzMmBJr7QUq8So