### PR TITLE
ci: deploy database rules with functions on push to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,10 +51,10 @@ jobs:
         run: npm ci
         working-directory: functions
 
-      - name: Deploy functions to Firebase
+      - name: Deploy functions and database rules to Firebase
         run: |
           echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_3AE94 }}' > /tmp/sa.json
-          npx firebase-tools@latest deploy --only functions --project board-game-calendar-3ae94
+          npx firebase-tools@latest deploy --only functions,database --project board-game-calendar-3ae94
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Pre-commit hooks run `yarn lint` via husky + lint-staged. Commits must follow Co
 - `helpers/constants.ts` — `LoadingTimeoutInMs`, `DebounceThrottleInMs`, BGG API constants
 - `helpers/helpers.ts` — `handleError()`, HTML entity decoding for BGG API responses
 - `firebase.json` — Firebase Hosting config
-- `database.rules.json` — Firebase Realtime DB security rules (deploy separately via Firebase CLI)
+- `database.rules.json` — Firebase Realtime DB security rules (deployed by `cd.yml` on push to `main`, alongside functions)
 
 ### Components
 
@@ -132,7 +132,7 @@ type EventType = {
 
 ## Firebase Security Rules
 
-`database.rules.json` covers `users/` and `gatherings/` (deploy separately via Firebase CLI: `firebase deploy --only database`):
+`database.rules.json` covers `users/` and `gatherings/` (deployed automatically by `cd.yml` on push to `main`; manual deploy: `firebase deploy --only database`):
 
 - `users/` — readable by any authenticated user (required for friend search queries on `queryableName`, which is indexed via `.indexOn`); each user can write only their own subtree; field-level `.validate` rules bound types and lengths.
 - `gatherings/` — readable by any authenticated user (rules are not filters; the calendar filters client-side for MVP); only the host can create/modify/delete a gathering; an invited guest can write only their own `guests/{uid}` response (`'invited' | 'accepted' | 'declined'`).


### PR DESCRIPTION
## Fixes the `permission_denied at /gatherings` toast in production

The gatherings security rules from #418 only exist in git — nothing deploys `database.rules.json`, so the Firebase server still enforces the old rules (everything outside `users/` denied). Every gatherings read/write in the merged app therefore fails with `permission_denied`, surfaced by the error toast.

### Change

- `cd.yml`: the existing Firebase deploy step now runs `deploy --only functions,database`, using the same `FIREBASE_SERVICE_ACCOUNT_3AE94` credentials. Rules deploy automatically on every push to `main`, so they can never drift from the app again.
- CLAUDE.md updated to reflect that rules are deployed by CD (manual `firebase deploy --only database` still documented as the fallback).

### Notes

- **Merging this PR triggers CD and deploys the current rules** — that alone should clear the toast. If you want it fixed before merging, run `npx firebase-tools deploy --only database --project board-game-calendar-3ae94` locally.
- The service account already deploys functions; if it unexpectedly lacks the RTDB-admin permission, the deploy step will fail visibly in Actions and the SA needs the Firebase Realtime Database Admin role added.

https://claude.ai/code/session_014r58WyDwDzMmBJr7QUq8So

---
_Generated by [Claude Code](https://claude.ai/code/session_014r58WyDwDzMmBJr7QUq8So)_