### PR TITLE
fix(friends): correct search placeholder text

### DIFF
--- a/pages/friends.vue
+++ b/pages/friends.vue
@@ -40,7 +40,7 @@
           </v-list>
         </v-card-text>
         <v-card-text v-else class="pa-6">
-          <v-text-field v-model="searchInput" label="Search for friends" placeholder="Search by name or email" :hint="`Type at least ${constants.MinSearchLength} characters`" persistent-hint prepend-inner-icon="mdi-magnify" clearable class="mb-4" />
+          <v-text-field v-model="searchInput" label="Search for friends" placeholder="Search by name" :hint="`Type at least ${constants.MinSearchLength} characters`" persistent-hint prepend-inner-icon="mdi-magnify" clearable class="mb-4" />
           <v-list>
             <v-list-item v-for="(person, id) in searchResults" :key="id" :title="person.name" :subtitle="person.email" class="friend-item mb-1">
               <template #prepend>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Removes "or email" from the search placeholder since email search is not implemented — only name search (`queryableName`) is supported

## Test plan
- [ ] Open the Friends page and click Add
- [ ] Confirm the search field now reads "Search by name" instead of "Search by name or email"

https://claude.ai/code/session_01DCtzScSmF628ziHvud6VaZ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCtzScSmF628ziHvud6VaZ)_