### PR TITLE
feat: remove open gathering feature

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -69,15 +69,12 @@
         "initiator": {
           ".validate": "newData.isString() && newData.val().length <= 128"
         },
-        "open": {
-          ".validate": "newData.isBoolean()"
-        },
         "maxGuests": {
           ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 1000"
         },
         "guests": {
           "$guestUid": {
-            ".write": "auth != null && $guestUid === auth.uid && (data.exists() || (newData.val() === 'accepted' && data.parent().parent().child('open').val() === true && data.parent().parent().child('state').val() !== 'canceled'))",
+            ".write": "auth != null && $guestUid === auth.uid && data.exists()",
             ".validate": "newData.val() === 'invited' || newData.val() === 'accepted' || newData.val() === 'declined'"
           }
         },

--- a/helpers/gatherings.ts
+++ b/helpers/gatherings.ts
@@ -7,25 +7,11 @@ const byDatetime = (a: GatheringWithId, b: GatheringWithId) =>
 
 // Rules are not filters: any signed-in user may read gatherings, so the
 // calendar loads them all and splits them client-side (MVP approach)
-export function splitGatherings(
-  gatherings: GatheringWithId[],
-  uid: string,
-  now: number = Date.now()
-) {
+export function splitGatherings(gatherings: GatheringWithId[], uid: string) {
   return {
     hosting: gatherings.filter((g) => g.host === uid).sort(byDatetime),
     invited: gatherings
       .filter((g) => g.host !== uid && g.guests?.[uid])
-      .sort(byDatetime),
-    open: gatherings
-      .filter(
-        (g) =>
-          g.host !== uid &&
-          !g.guests?.[uid] &&
-          g.open &&
-          g.state !== 'canceled' &&
-          new Date(g.datetime).getTime() > now
-      )
       .sort(byDatetime),
   }
 }

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -38,7 +38,6 @@ export type Gathering = {
   datetime: string // ISO date
   initiator: string // uid
   host: string // uid
-  open: boolean
   maxGuests: number
   guests?: Record<string, GuestResponse> // keyed by guest uid
   games?: GatheringGame[]

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -14,7 +14,7 @@
         <v-card-text v-if="loading" class="pa-8">
           <v-progress-linear indeterminate color="primary" />
         </v-card-text>
-        <v-card-text v-else-if="!hosting.length && !invited.length && !openGatherings.length" class="pa-6">
+        <v-card-text v-else-if="!hosting.length && !invited.length" class="pa-6">
           <div class="empty-state">
             <v-icon size="64" color="primary" class="mb-4" style="opacity: 0.3">mdi-calendar-blank-outline</v-icon>
             <div class="empty-title">No gatherings yet</div>
@@ -61,32 +61,8 @@
             </div>
           </template>
 
-          <template v-if="openGatherings.length">
-            <div class="section-title mb-3" :class="{ 'mt-4': hosting.length }">Open gatherings</div>
-            <div v-for="gathering in openGatherings" :key="gathering.id" class="event-item pa-4 mb-3">
-              <div class="d-flex align-center flex-wrap mb-2">
-                <v-chip :color="stateColor(gathering.state)" size="small" variant="tonal" class="mr-2 text-capitalize">{{ gathering.state }}</v-chip>
-                <span class="event-line"><v-icon size="16" class="mr-1">mdi-clock-outline</v-icon>{{ formatDatetime(gathering.datetime) }}</span>
-                <v-spacer />
-                <v-btn density="compact" size="small" variant="tonal" color="success" :disabled="isFull(gathering)" @click.stop="respond(gathering, 'accepted')">
-                  <v-icon start>mdi-account-plus</v-icon>{{ isFull(gathering) ? 'Full' : 'Join' }}
-                </v-btn>
-              </div>
-              <div class="event-line mb-2">
-                <v-icon size="16" class="mr-1">mdi-account</v-icon>Hosted by {{ names[gathering.host] ?? '…' }}
-                <template v-if="gathering.maxGuests > 0">
-                  <span class="mx-2">·</span>{{ acceptedCount(gathering) }}/{{ gathering.maxGuests }} guests
-                </template>
-              </div>
-              <div v-if="gathering.games?.length" class="event-line">
-                <v-icon size="16" class="mr-1">mdi-rhombus-split</v-icon>
-                <v-chip v-for="game in gathering.games" :key="game.id" size="x-small" variant="outlined" class="mr-1">{{ game.name }}</v-chip>
-              </div>
-            </div>
-          </template>
-
           <template v-if="invited.length">
-            <div class="section-title mb-3" :class="{ 'mt-4': hosting.length || openGatherings.length }">Invited</div>
+            <div class="section-title mb-3" :class="{ 'mt-4': hosting.length }">Invited</div>
             <div v-for="gathering in invited" :key="gathering.id" class="event-item pa-4 mb-3">
               <div class="d-flex align-center flex-wrap mb-2">
                 <v-chip :color="stateColor(gathering.state)" size="small" variant="tonal" class="mr-2 text-capitalize">{{ gathering.state }}</v-chip>
@@ -125,8 +101,6 @@ import routes from '~/helpers/routes'
 import constants from '~/helpers/constants'
 import {
   splitGatherings,
-  acceptedCount,
-  isFull,
   stateColor,
   responseColor,
   responseIcon,
@@ -170,12 +144,11 @@ onUnmounted(() => { unsubscribe?.() })
 const sections = computed(() => splitGatherings(gatherings.value, uid))
 const hosting = computed(() => sections.value.hosting)
 const invited = computed(() => sections.value.invited)
-const openGatherings = computed(() => sections.value.open)
 
 async function resolveNames() {
   const wanted = new Set<string>()
   for (const gathering of sections.value.hosting) Object.keys(gathering.guests ?? {}).forEach((guestUid) => wanted.add(guestUid))
-  for (const gathering of [...sections.value.invited, ...sections.value.open]) wanted.add(gathering.host)
+  for (const gathering of sections.value.invited) wanted.add(gathering.host)
   const missing = [...wanted].filter((personUid) => !(personUid in names.value))
   await Promise.all(missing.map(async (personUid) => {
     try {

--- a/pages/gatherings/new.vue
+++ b/pages/gatherings/new.vue
@@ -20,8 +20,7 @@
                 <v-text-field v-model="time" type="time" label="Start time" :rules="[validation.isRequired]" prepend-inner-icon="mdi-clock-outline" />
               </v-col>
             </v-row>
-            <v-text-field v-model="maxGuests" type="number" label="Max guests" :rules="[validation.isMaxGuests]" prepend-inner-icon="mdi-account-multiple-outline" class="mb-1" />
-            <v-switch v-model="open" color="primary" label="Open gathering" hint="Open gatherings can be seen by all signed-in users, not just invited guests" persistent-hint class="mb-3" />
+            <v-text-field v-model="maxGuests" type="number" label="Max guests" :rules="[validation.isMaxGuests]" prepend-inner-icon="mdi-account-multiple-outline" class="mb-3" />
             <v-select v-model="selectedGuests" :items="friendItems" multiple chips closable-chips label="Invite friends" prepend-inner-icon="mdi-account-group" :hint="friendItems.length ? '' : 'Add friends on the Friends page to invite them'" persistent-hint class="mb-1" />
             <v-select v-model="selectedGameIds" :items="gameItems" multiple chips closable-chips label="Games to play" prepend-inner-icon="mdi-rhombus-split" :hint="gameItems.length ? '' : 'Add games on the Game Collection page to pick them'" persistent-hint class="mb-4" />
             <v-btn type="submit" block color="primary" size="large" :loading="saving">
@@ -58,7 +57,6 @@ const saving = ref(false)
 const date = ref('')
 const time = ref('')
 const maxGuests = ref<number | string>(0)
-const open = ref(false)
 const selectedGuests = ref<string[]>([])
 const selectedGameIds = ref<string[]>([])
 const friendItems = ref<{ title: string; value: string }[]>([])
@@ -124,7 +122,6 @@ onMounted(async () => {
       date.value = `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}`
       time.value = `${pad(dt.getHours())}:${pad(dt.getMinutes())}`
       maxGuests.value = gathering.maxGuests
-      open.value = gathering.open
       selectedGuests.value = Object.keys(existingGuests)
       selectedGameIds.value = (gathering.games ?? []).map((game) => game.id)
       // Keep invited guests visible even if they are no longer friends
@@ -169,7 +166,6 @@ async function createGathering() {
       datetime: datetime.toISOString(),
       initiator: uid,
       host: uid,
-      open: open.value,
       maxGuests: Number(maxGuests.value || 0),
       // existing guests keep their response when editing; new ones start as invited
       guests: Object.fromEntries(selectedGuests.value.map((guestId) => [guestId, existingGuests[guestId] ?? ('invited' as GuestResponse)])),

--- a/test/gatherings.spec.ts
+++ b/test/gatherings.spec.ts
@@ -8,9 +8,7 @@ import {
 } from '~/helpers/gatherings'
 import type { Gathering } from '~/helpers/types'
 
-const NOW = new Date('2026-06-01T12:00:00Z').getTime()
 const FUTURE = '2026-07-01T19:00:00.000Z'
-const PAST = '2026-05-01T19:00:00.000Z'
 
 function gathering(overrides: Partial<GatheringWithId>): GatheringWithId {
   return {
@@ -19,49 +17,21 @@ function gathering(overrides: Partial<GatheringWithId>): GatheringWithId {
     datetime: FUTURE,
     initiator: 'host1',
     host: 'host1',
-    open: false,
     maxGuests: 4,
     ...overrides,
   }
 }
 
 describe('splitGatherings', () => {
-  it('splits into hosting, invited, and open sections', () => {
+  it('splits into hosting and invited sections', () => {
     const all = [
       gathering({ id: 'mine', host: 'me' }),
       gathering({ id: 'inv', guests: { me: 'invited' } }),
-      gathering({ id: 'open', open: true }),
-      gathering({ id: 'closed' }),
+      gathering({ id: 'other' }),
     ]
-    const { hosting, invited, open } = splitGatherings(all, 'me', NOW)
+    const { hosting, invited } = splitGatherings(all, 'me')
     expect(hosting.map((g) => g.id)).toEqual(['mine'])
     expect(invited.map((g) => g.id)).toEqual(['inv'])
-    expect(open.map((g) => g.id)).toEqual(['open'])
-  })
-
-  it('does not list my own or already-joined gatherings as open', () => {
-    const all = [
-      gathering({ id: 'mine', host: 'me', open: true }),
-      gathering({ id: 'joined', open: true, guests: { me: 'accepted' } }),
-    ]
-    const { invited, open } = splitGatherings(all, 'me', NOW)
-    expect(open).toEqual([])
-    expect(invited.map((g) => g.id)).toEqual(['joined'])
-  })
-
-  it('hides past and canceled gatherings from the open section only', () => {
-    const all = [
-      gathering({ id: 'past', open: true, datetime: PAST }),
-      gathering({ id: 'canceled', open: true, state: 'canceled' }),
-      gathering({
-        id: 'pastInvite',
-        datetime: PAST,
-        guests: { me: 'invited' },
-      }),
-    ]
-    const { invited, open } = splitGatherings(all, 'me', NOW)
-    expect(open).toEqual([])
-    expect(invited.map((g) => g.id)).toEqual(['pastInvite'])
   })
 
   it('sorts each section by datetime ascending', () => {
@@ -69,7 +39,7 @@ describe('splitGatherings', () => {
       gathering({ id: 'later', host: 'me', datetime: '2026-08-01T19:00:00.000Z' }),
       gathering({ id: 'sooner', host: 'me', datetime: FUTURE }),
     ]
-    expect(splitGatherings(all, 'me', NOW).hosting.map((g) => g.id)).toEqual([
+    expect(splitGatherings(all, 'me').hosting.map((g) => g.id)).toEqual([
       'sooner',
       'later',
     ])

--- a/test/rules/database.rules.spec.ts
+++ b/test/rules/database.rules.spec.ts
@@ -45,7 +45,6 @@ const baseGathering = {
   datetime: '2026-07-01T19:00:00.000Z',
   initiator: 'host1',
   host: 'host1',
-  open: false,
   maxGuests: 4,
   guests: { guest1: 'invited' },
   games: [{ id: '13', name: 'Catan' }],
@@ -197,23 +196,8 @@ describe('gatherings rules', () => {
     )
   })
 
-  it('lets a signed-in user join an open gathering by accepting', async () => {
-    await seed('gatherings/g1', { ...baseGathering, open: true })
-    await assertSucceeds(
-      set(ref(db('walkin'), 'gatherings/g1/guests/walkin'), 'accepted')
-    )
-    // joining is accept-only; you can't add yourself as merely invited
-    await assertFails(
-      set(ref(db('other'), 'gatherings/g1/guests/other'), 'invited')
-    )
-  })
-
-  it('blocks joining a canceled open gathering', async () => {
-    await seed('gatherings/g1', {
-      ...baseGathering,
-      open: true,
-      state: 'canceled',
-    })
+  it('blocks uninvited users from writing a guest response', async () => {
+    await seed('gatherings/g1', baseGathering)
     await assertFails(
       set(ref(db('walkin'), 'gatherings/g1/guests/walkin'), 'accepted')
     )


### PR DESCRIPTION
## Summary

- Removes the `open` boolean field from the `Gathering` type and all related UI/logic
- Drops the "Open gathering" toggle from the new/edit gathering form
- Removes the "Open gatherings" calendar section and all associated computed properties
- Updates Firebase DB security rules: guests can only write their own response if they already exist in the guest list (no more walk-in joins)
- Cleans up unit tests and rules tests accordingly

## Test plan

- [ ] Create a gathering — no "Open gathering" switch visible
- [ ] Calendar shows only Hosting and Invited sections
- [ ] Existing invited guests can still accept/decline
- [ ] `yarn lint` passes
- [ ] `yarn test` passes (9 tests)

https://claude.ai/code/session_013rHXKmHwB5KepuaJaHZASV

---
_Generated by [Claude Code](https://claude.ai/code/session_013rHXKmHwB5KepuaJaHZASV)_