### PR TITLE
docs: update README to reflect current stack and data model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ Single test in `test/Logo.spec.ts`. Vitest requires `environment: 'jsdom'` (set 
 
 ## Pull Requests
 
-When writing PR descriptions (e.g. via `mcp__github__create_pull_request`), pass the `body` string as a plain JSON string — **never** wrap it in a shell heredoc like `$(cat <<'EOF' ... EOF)`. The GitHub MCP tool receives the value directly as a JSON parameter; heredoc syntax will be passed literally as the PR body text rather than being interpolated.
+When writing PR descriptions (e.g. via `mcp__github__create_pull_request`), pass the `body` string as a plain JSON string — **never** wrap it in a shell heredoc like `$(cat <<'EOF' ... EOF)`. The GitHub MCP tool receives the value directly as a JSON parameter; heredoc syntax will be passed literally as the PR body text rather than being interpolated. Similarly, do **not** use `\n` escape sequences in the body string — use actual line breaks in the JSON string value instead.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Schedule board game nights around the games you love — not the ones that attra
 ## What it does
 
 - Build your personal board game collection with ratings pulled from BoardGameGeek
-- Add friends and see who's available
+- Add friends and manage friend requests
 - Create and manage game night gatherings with specific games and guest lists
 
 ## Tech stack
 
-- [Nuxt 4](https://nuxt.com) (Vue 3, SSR disabled)
-- [Vuetify 4](https://vuetifyjs.com) — component library and design system
-- [Firebase](https://firebase.google.com) — Realtime Database, Auth, Hosting, Remote Config
+- [Nuxt 4](https://nuxt.com) (Vue 3, static generation)
+- [Vuetify 4](https://vuetifyjs.com) — Material Design 3 component library (dark theme)
+- [Firebase](https://firebase.google.com) — Realtime Database, Auth, Analytics
 - [Pinia](https://pinia.vuejs.org) — state management
 - [Vitest](https://vitest.dev) — unit testing
 - TypeScript throughout
@@ -23,11 +23,17 @@ Schedule board game nights around the games you love — not the ones that attra
 # Install dependencies (Yarn required)
 yarn install
 
+# Regenerate .nuxt/ types after install
+yarn postinstall
+
 # Start dev server on port 3005
 yarn dev
 
-# Run tests
+# Run unit tests
 yarn test
+
+# Run Firebase security rules tests (requires Java + RTDB emulator)
+yarn test:rules
 
 # Lint
 yarn lint
@@ -36,50 +42,51 @@ yarn lint
 ## Build & deploy
 
 ```bash
-# Build for production
-yarn build
-
-# Generate static output
+# Generate static output → dist/
 yarn generate
 ```
 
-Deployed via Firebase Hosting. See `firebase.json` for hosting config and `.firebaserc` for project aliases.
+Deployed to GitHub Pages via GitHub Actions (`.github/workflows/cd.yml`) on push to `main`. Firebase Realtime Database security rules are also deployed automatically from `database.rules.json`.
 
 ## Data model
 
+### Firebase paths
+
+| Path | Description |
+|------|-------------|
+| `users/{uid}` | User profile |
+| `users/{uid}/collection/{pushId}` | Game in user's collection |
+| `users/{uid}/friends/{friendId}` | Mutual friend (value: `true`) |
+| `users/{uid}/friendRequests/{fromUid}` | Incoming request (value: `'pending'`) |
+| `users/{uid}/blocked/{blockedUid}` | Blocked user (value: `true`) |
+| `gatherings/{pushId}` | A game night gathering |
+
 ### Types
 
-| Type | Values |
-|------|--------|
-| `GatheringState` | `pending` \| `confirmed` \| `canceled` |
-
-### Collections
-
-**user**
-- `id: uuid`
+**User** (`users/{uid}`)
 - `name: string`
-- `queryableName: string` (lowercase, used for search)
 - `email: string`
 - `phoneNumber: string`
 - `address: string`
 - `maxPeople: number`
-- `collection: Record<string, Game>`
-- `friends: Record<uid, true>`
+- `queryableName: string` — lowercase name, indexed for friend search
+- `queryableEmail: string` — lowercase email, indexed for friend search
+- `queryablePhone: string` — digits-only phone, indexed for friend search
 
-**Game**
-- `id: number` (BoardGameGeek ID)
+**Game** (`users/{uid}/collection/{pushId}`)
+- `id: string` — BoardGameGeek game ID
 - `name: string`
-- `rating: number`
+- `rating?: number`
 
-**gathering**
-- `state: GatheringState`
-- `datetime: DateTime`
-- `initiator: uuid`
-- `host: uuid`
+**Gathering** (`gatherings/{pushId}`)
+- `state: 'pending' | 'confirmed' | 'canceled'`
+- `datetime: string` — ISO date
+- `initiator: string` — uid
+- `host: string` — uid
 - `open: boolean`
 - `maxGuests: number`
-- `guests: Guest[]`
-- `games: id[]`
+- `guests?: Record<string, 'invited' | 'accepted' | 'declined'>` — keyed by uid
+- `games?: { id: string, name: string }[]` — denormalized from host's collection
 
 ## Project structure
 
@@ -87,12 +94,13 @@ Deployed via Firebase Hosting. See `firebase.json` for hosting config and `.fire
 pages/          # Route pages (Nuxt file-based routing)
 components/     # Shared Vue components
 stores/         # Pinia stores
-helpers/        # Types, constants, validation helpers
-layouts/        # App shell (nav drawer, app bar, footer)
+helpers/        # Types, constants, route/name helpers
+layouts/        # App shell (nav drawer, app bar)
 assets/         # Global SCSS and Vuetify variable overrides
-plugins/        # Nuxt plugins (Firebase init)
+plugins/        # Nuxt plugins (Firebase init, auth hydration)
+middleware/     # Global route middleware (auth guard)
 ```
 
 ## Contributing
 
-Commits follow [Conventional Commits](https://www.conventionalcommits.org). Husky + commitlint enforce this on commit.
+Commits follow [Conventional Commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `chore:`, etc.). Husky + lint-staged enforce linting on commit.


### PR DESCRIPTION
The README had several inaccuracies compared to the actual codebase. This corrects them.

**Fixes:**
- Deployment: GitHub Pages, not Firebase Hosting
- Remove `yarn build` (unused); add `yarn postinstall` and `yarn test:rules`
- Data model: add `queryableEmail`, `queryablePhone`, `friendRequests`, `blocked`; fix `Game`, `Gathering`, and `GuestResponse` types
- Tech stack: remove Firebase Remote Config; note static generation
- Project structure: add `middleware/`
- Contributing: husky + lint-staged (not commitlint)