### PR TITLE
fix(rules): require bilateral friendship for collection read

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -36,7 +36,7 @@
           ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 1000"
         },
         "collection": {
-          ".read": "$uid === auth.uid || root.child('users').child(auth.uid).child('friends').child($uid).val() === true",
+          ".read": "$uid === auth.uid || (root.child('users').child(auth.uid).child('friends').child($uid).val() === true && root.child('users').child($uid).child('friends').child(auth.uid).val() === true)",
           "$pushId": {
             "id": {
               ".validate": "newData.isString() && newData.val().length <= 20"


### PR DESCRIPTION
## Summary

The collection read rule added in #439 only checked one side of the friendship: whether the viewer's own `users/{viewerUid}/friends/{ownerUid}` entry was `true`. Because `users/{uid}` has a blanket owner-write permission, any user can freely write arbitrary entries into their own friends list — including adding a stranger — and thereby gain read access to that stranger's collection without their consent.

## Fix

Changed to a bilateral check: both `users/{viewerUid}/friends/{ownerUid}` **and** `users/{ownerUid}/friends/{viewerUid}` must be `true`. The second condition is under the collection owner's path and cannot be forged by the viewer, so access is only granted when both parties have genuinely accepted the friendship.

```json
".read": "$uid === auth.uid || (root.child('users').child(auth.uid).child('friends').child($uid).val() === true && root.child('users').child($uid).child('friends').child(auth.uid).val() === true)"
```

## Test plan

- [ ] Mutual friends can still read each other's collections
- [ ] A user who unilaterally adds a stranger to their own friends list (via a direct DB write) cannot read that stranger's collection
- [ ] Removing one side of a friendship (unfriend) revokes collection access for both parties

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSHqNqN1zwK6hRU6yi2gUM)_