### PR TITLE
feat(bgg): batch thing queries into a single BGG API call

### DIFF
--- a/composables/useBoardGameSearch.ts
+++ b/composables/useBoardGameSearch.ts
@@ -74,15 +74,12 @@ export function useBoardGameSearch(
   async function displayEntries() {
     try {
       const entries = _getEntriesToShow()
-      const bggThingFn = httpsCallable<{ id: string }, BggThingResult>(
+      const bggThingFn = httpsCallable<{ ids: string[] }, { items: BggThingResult[] }>(
         $functions,
         'bggThing'
       )
-      const results = await Promise.all(
-        entries.map((entry) => bggThingFn({ id: entry.id }))
-      )
-      queriedEntries.value = results
-        .map((r) => r.data)
+      const result = await bggThingFn({ ids: entries.map((e) => e.id) })
+      queriedEntries.value = (result.data.items ?? [])
         .filter((item): item is BggThingResult => !!item)
         .map((item) => {
           const thumb = item.thumbnail ?? ''

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -105,13 +105,49 @@ export const bggSearch = onCall(
   }
 )
 
+function parseBggThingItem(item: unknown) {
+  const itemObj = item as Record<string, unknown>
+  const itemId = itemAttr(item, 'id')
+  if (!itemId) return null
+
+  const nameField = itemObj.name
+  const nameArray: unknown[] = Array.isArray(nameField) ? nameField : [nameField]
+  const primaryNameNode = nameArray.find((n) => itemAttr(n, 'type') === 'primary') ?? nameArray[0]
+  const name = attrValue(primaryNameNode) ?? ''
+
+  const descriptionRaw = first(itemObj.description)
+  const imageRaw = first(itemObj.image)
+  const thumbnailRaw = first(itemObj.thumbnail)
+
+  const imageUrl = typeof imageRaw === 'string' ? imageRaw : ''
+  const thumbnailUrl = typeof thumbnailRaw === 'string' && thumbnailRaw ? thumbnailRaw : imageUrl
+
+  return {
+    id: itemId,
+    name,
+    description: typeof descriptionRaw === 'string' ? descriptionRaw : '',
+    image: imageUrl,
+    thumbnail: thumbnailUrl,
+    yearpublished: attrValue(itemObj.yearpublished),
+    minplayers: attrValue(itemObj.minplayers),
+    maxplayers: attrValue(itemObj.maxplayers),
+    minplaytime: attrValue(itemObj.minplaytime),
+    maxplaytime: attrValue(itemObj.maxplaytime),
+    minage: attrValue(itemObj.minage),
+  }
+}
+
 export const bggThing = onCall(
   { enforceAppCheck: true, secrets: [BGG_API_KEY] },
   async (request) => {
-    const { id } = request.data as { id: string }
-    if (!id) throw new HttpsError('invalid-argument', 'Missing id')
+    const { ids } = request.data as { ids: string[] }
+    if (!Array.isArray(ids) || ids.length === 0)
+      throw new HttpsError('invalid-argument', 'Missing ids')
+    if (ids.length > 20) throw new HttpsError('invalid-argument', 'Too many ids (max 20)')
+    if (ids.some((id) => !/^\d+$/.test(id)))
+      throw new HttpsError('invalid-argument', 'Invalid id format')
 
-    const params = new URLSearchParams({ id }).toString()
+    const params = new URLSearchParams({ id: ids.join(',') }).toString()
     const url = `${BGG_BASE_URL}/thing?${params}`
     console.log(`Proxying thing to BGG: ${url}`)
 
@@ -136,40 +172,13 @@ export const bggThing = onCall(
       throw new HttpsError('internal', 'Unexpected response format from BGG')
     }
 
-    const item = first((rawItems as Record<string, unknown>).item)
-    if (item == null || typeof item !== 'object') {
-      throw new HttpsError('not-found', 'Item not found')
-    }
+    const itemField = (rawItems as Record<string, unknown>).item ?? []
+    const itemArray: unknown[] = Array.isArray(itemField) ? itemField : [itemField]
 
-    const itemObj = item as Record<string, unknown>
-    const itemId = itemAttr(item, 'id')
-    if (!itemId) throw new HttpsError('not-found', 'Item missing id')
+    const items = itemArray
+      .map(parseBggThingItem)
+      .filter((item): item is NonNullable<ReturnType<typeof parseBggThingItem>> => item !== null)
 
-    const nameField = itemObj.name
-    const nameArray: unknown[] = Array.isArray(nameField) ? nameField : [nameField]
-    const primaryNameNode = nameArray.find((n) => itemAttr(n, 'type') === 'primary') ?? nameArray[0]
-    const name = attrValue(primaryNameNode) ?? ''
-
-    // xml2js wraps text-only nodes as string arrays; unwrap with first()
-    const descriptionRaw = first(itemObj.description)
-    const imageRaw = first(itemObj.image)
-    const thumbnailRaw = first(itemObj.thumbnail)
-
-    const imageUrl = typeof imageRaw === 'string' ? imageRaw : ''
-    const thumbnailUrl = typeof thumbnailRaw === 'string' && thumbnailRaw ? thumbnailRaw : imageUrl
-
-    return {
-      id: itemId,
-      name,
-      description: typeof descriptionRaw === 'string' ? descriptionRaw : '',
-      image: imageUrl,
-      thumbnail: thumbnailUrl,
-      yearpublished: attrValue(itemObj.yearpublished),
-      minplayers: attrValue(itemObj.minplayers),
-      maxplayers: attrValue(itemObj.maxplayers),
-      minplaytime: attrValue(itemObj.minplaytime),
-      maxplaytime: attrValue(itemObj.maxplaytime),
-      minage: attrValue(itemObj.minage),
-    }
+    return { items }
   }
 )

--- a/pages/gamecollection.vue
+++ b/pages/gamecollection.vue
@@ -579,9 +579,10 @@ function buildGame(id: string, data: BggGameMeta, fallbackName: string): Game {
 }
 
 async function fetchAndCollect(id: string, fallbackName: string): Promise<void> {
-  const fn = httpsCallable<{ id: string }, BggGameMeta>($functions, 'bggThing')
-  const { data } = await fn({ id })
-  await set(push(dbRef(db, `users/${ownUid}/collection`)), buildGame(id, data, fallbackName))
+  const fn = httpsCallable<{ ids: string[] }, { items: BggGameMeta[] }>($functions, 'bggThing')
+  const { data } = await fn({ ids: [id] })
+  const item = data.items?.[0] ?? {}
+  await set(push(dbRef(db, `users/${ownUid}/collection`)), buildGame(id, item, fallbackName))
 }
 
 async function addToCollection(item: DisplayableItemType) {


### PR DESCRIPTION
## Summary

-  now accepts  instead of a single , joins them as a comma-separated param (), and returns 
-  replaces  over N individual function calls with a single batched call
-  updated to pass  and unwrap the first result

## Why

Each search result previously triggered its own Cloud Function invocation and upstream BGG API request. With up to 10 results shown at once, that was 10 round-trips per search. BGG's  endpoint natively supports batching via comma-separated IDs, so this collapses them into one.

## Reviewer notes

- Max 20 IDs enforced server-side; numeric-only validation added
- Response shape changed from a single object to  — both call sites updated
- The  helper was extracted to avoid duplicating field-extraction logic across the multi-item loop

## Test plan

- [ ] Search for a game in the game collection page — results should still populate with full detail (thumbnail, players, playtime, etc.)
- [ ] Select a specific game from search results — detail view should load correctly
- [ ] Add a game to collection via search — should save to Firebase with correct metadata
- [ ] Confirm only one Cloud Function call is made per search (check Firebase console or browser network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)