### PR TITLE
fix: thumbnail fallback to image, larger collection buttons

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -153,15 +153,17 @@ export const bggThing = onCall(
     // xml2js wraps text-only nodes as string arrays; unwrap with first()
     const descriptionRaw = first(itemObj.description)
     const imageRaw = first(itemObj.image)
-
     const thumbnailRaw = first(itemObj.thumbnail)
+
+    const imageUrl = typeof imageRaw === 'string' ? imageRaw : ''
+    const thumbnailUrl = typeof thumbnailRaw === 'string' && thumbnailRaw ? thumbnailRaw : imageUrl
 
     return {
       id: itemId,
       name,
       description: typeof descriptionRaw === 'string' ? descriptionRaw : '',
-      image: typeof imageRaw === 'string' ? imageRaw : '',
-      thumbnail: typeof thumbnailRaw === 'string' ? thumbnailRaw : '',
+      image: imageUrl,
+      thumbnail: thumbnailUrl,
       yearpublished: attrValue(itemObj.yearpublished),
       minplayers: attrValue(itemObj.minplayers),
       maxplayers: attrValue(itemObj.maxplayers),

--- a/pages/gamecollection.vue
+++ b/pages/gamecollection.vue
@@ -121,7 +121,7 @@
                       {{ formatGameInfo(item) }}
                     </div>
                     <template #append>
-                      <div class="d-flex align-center gap-2">
+                      <div class="d-flex align-center">
                         <v-btn
                           size="small"
                           variant="text"
@@ -203,7 +203,7 @@
                       "
                     />
                     <template #append>
-                      <div class="d-flex align-center gap-2">
+                      <div class="d-flex align-center">
                         <v-btn
                           size="small"
                           variant="text"


### PR DESCRIPTION
Two fixes on top of the already-merged collection redesign:

- **`bggThing` thumbnail fallback**: BGG doesn't always return a `<thumbnail>` element. When it's absent the function was returning `thumbnail: ''`, causing blank avatars. Now falls back to the `image` URL (which BGG always returns).
- **Collection action buttons**: removes the `gap-2` flex gap that wasn't rendering in the append slot context; button padding provides visual separation at the correct `size="small"` height.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfjJeY6LnonNJVE5JkNRLk)_