### PR TITLE
feat: add Firebase Analytics event tracking

### DIFF
--- a/composables/useFriendActions.ts
+++ b/composables/useFriendActions.ts
@@ -6,15 +6,19 @@ import { ref as dbRef, set, update } from 'firebase/database'
 // remove it), so callers should expect permission errors — e.g. when blocked.
 export function useFriendActions() {
   const userStore = useUserStore()
-  const db = useNuxtApp().$db
+  const nuxtApp = useNuxtApp()
+  const db = nuxtApp.$db
+  const logEvent = nuxtApp.$logEvent
 
   const ownUid = () => userStore.user!.uid
 
   function sendFriendRequest(targetUid: string) {
+    logEvent('friend_request_sent')
     return set(dbRef(db, `friendRequests/${targetUid}/${ownUid()}`), 'pending')
   }
 
   function acceptRequest(fromUid: string) {
+    logEvent('friend_request_accepted')
     const uid = ownUid()
     return update(dbRef(db), {
       [`users/${uid}/friends/${fromUid}`]: true,
@@ -24,6 +28,7 @@ export function useFriendActions() {
   }
 
   function declineRequest(fromUid: string) {
+    logEvent('friend_request_declined')
     const uid = ownUid()
     return update(dbRef(db), {
       [`blocked/${uid}/${fromUid}`]: true,
@@ -32,6 +37,7 @@ export function useFriendActions() {
   }
 
   function removeFriend(friendId: string) {
+    logEvent('friend_removed')
     const uid = ownUid()
     return update(dbRef(db), {
       [`users/${uid}/friends/${friendId}`]: null,

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -115,6 +115,7 @@ const userStore = useUserStore()
 const router = useRouter()
 const nuxtApp = useNuxtApp()
 const db = nuxtApp.$db
+const logEvent = nuxtApp.$logEvent
 
 const snackbar = ref<InstanceType<typeof Snackbar> | null>(null)
 // gatherings are readable only by their participants, so the calendar follows
@@ -187,12 +188,18 @@ function myResponse(gathering: Gathering): GuestResponse | undefined {
 }
 
 async function setState(gathering: GatheringWithId, state: GatheringState) {
-  try { await update(dbRef(db, `gatherings/${gathering.id}`), { state }) }
+  try {
+    await update(dbRef(db, `gatherings/${gathering.id}`), { state })
+    logEvent('gathering_state_changed', { state })
+  }
   catch (err) { snackbar.value?.showSnackbarWithMessage(helpers.handleError(err).message, true) }
 }
 
 async function respond(gathering: GatheringWithId, response: GuestResponse) {
-  try { await set(dbRef(db, `gatherings/${gathering.id}/guests/${uid}`), response) }
+  try {
+    await set(dbRef(db, `gatherings/${gathering.id}/guests/${uid}`), response)
+    logEvent('gathering_rsvp', { response })
+  }
   catch (err) { snackbar.value?.showSnackbarWithMessage(helpers.handleError(err).message, true) }
 }
 
@@ -208,6 +215,7 @@ async function deleteGathering(gathering: GatheringWithId) {
       updates[`userGatherings/${guestUid}/${gathering.id}`] = null
     }
     await update(dbRef(db), updates)
+    logEvent('gathering_deleted')
   } catch (err) { snackbar.value?.showSnackbarWithMessage(helpers.handleError(err).message, true) }
 }
 

--- a/pages/gamecollection.vue
+++ b/pages/gamecollection.vue
@@ -386,6 +386,7 @@ const userStore = useUserStore()
 const nuxtApp = useNuxtApp()
 const db = nuxtApp.$db
 const $functions = nuxtApp.$functions
+const logEvent = nuxtApp.$logEvent
 const snackbar = ref<InstanceType<typeof Snackbar> | null>(null)
 
 const ownUid = userStore.user!.uid
@@ -608,6 +609,7 @@ async function addToCollection(item: DisplayableItemType) {
       push(dbRef(db, `users/${ownUid}/collection`)),
       buildGame(item.id, item, item.name)
     )
+    logEvent('game_added_to_collection', { name: item.name })
     activeArea.value = 'collection'
     snackbar.value?.showSnackbarWithMessage(`${item.name} added to collection`, false)
   } catch (err) {
@@ -621,6 +623,7 @@ async function addToCollection(item: DisplayableItemType) {
 async function removeGameFromCollection(id: string) {
   try {
     await remove(dbRef(db, `users/${ownUid}/collection/${id}`))
+    logEvent('game_removed_from_collection')
   } catch (err) {
     snackbar.value?.showSnackbarWithMessage(
       helpers.handleError(err).message,

--- a/plugins/01-firebase.client.ts
+++ b/plugins/01-firebase.client.ts
@@ -7,6 +7,7 @@ import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check'
 import {
   getAnalytics,
   logEvent as firebaseLogEvent,
+  setUserId as firebaseSetUserId,
   isSupported,
 } from 'firebase/analytics'
 import firebaseConf from '~/firebase.config'
@@ -39,10 +40,16 @@ export default defineNuxtPlugin(() => {
   const functions = getFunctions(app)
 
   let _analytics: ReturnType<typeof getAnalytics> | null = null
+  let _pendingUserId: string | null | undefined = undefined
 
   if (typeof window !== 'undefined') {
     isSupported().then((yes) => {
-      if (yes) _analytics = getAnalytics(app)
+      if (yes) {
+        _analytics = getAnalytics(app)
+        if (_pendingUserId !== undefined) {
+          firebaseSetUserId(_analytics, _pendingUserId)
+        }
+      }
     })
   }
 
@@ -63,6 +70,14 @@ export default defineNuxtPlugin(() => {
     logEvent(logLevel, { message, ...details })
   }
 
+  const setAnalyticsUserId = (uid: string | null): void => {
+    if (_analytics) {
+      firebaseSetUserId(_analytics, uid)
+    } else {
+      _pendingUserId = uid
+    }
+  }
+
   return {
     provide: {
       auth,
@@ -70,6 +85,7 @@ export default defineNuxtPlugin(() => {
       functions,
       logEvent,
       log,
+      setAnalyticsUserId,
     },
   }
 })

--- a/plugins/02-fireauth.client.ts
+++ b/plugins/02-fireauth.client.ts
@@ -2,7 +2,7 @@ import { onAuthStateChanged, getAuth } from 'firebase/auth'
 import { defineNuxtPlugin } from 'nuxt/app'
 import { useUserStore } from '~/stores/user'
 
-export default defineNuxtPlugin(async () => {
+export default defineNuxtPlugin(async (nuxtApp) => {
   const userStore = useUserStore()
   const auth = getAuth()
 
@@ -13,6 +13,7 @@ export default defineNuxtPlugin(async () => {
     let resolved = false
     onAuthStateChanged(auth, (user) => {
       userStore.setUser(user)
+      nuxtApp.$setAnalyticsUserId(user?.uid ?? null)
       if (!resolved) {
         resolved = true
         resolve()

--- a/plugins/03-analytics.client.ts
+++ b/plugins/03-analytics.client.ts
@@ -1,0 +1,20 @@
+import { nextTick } from 'vue'
+
+export default defineNuxtPlugin(() => {
+  const router = useRouter()
+  const { $logEvent } = useNuxtApp()
+  let initialNavDone = false
+
+  router.afterEach(async () => {
+    if (!initialNavDone) {
+      initialNavDone = true
+      return
+    }
+    await nextTick()
+    $logEvent('page_view', {
+      page_title: document.title,
+      page_location: window.location.href,
+      page_path: window.location.pathname,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Page views**: New `plugins/03-analytics.client.ts` fires `page_view` on every SPA route change. Firebase Analytics only auto-fires this on initial load — subsequent client-side navigations were silently untracked.
- **Friend actions**: `useFriendActions.ts` now fires `friend_request_sent`, `friend_request_accepted`, `friend_request_declined`, and `friend_removed`.
- **Calendar**: `calendar.vue` fires `gathering_state_changed` (confirm/cancel), `gathering_rsvp` (accept/decline invitation), and `gathering_deleted`.
- **Game collection**: `gamecollection.vue` fires `game_added_to_collection` (with game name) and `game_removed_from_collection`.

Already tracked before this PR: `login`, `sign_up` (in `useAuthSignIn`), `create_gathering`, `edit_gathering` (in `gatherings/new.vue`), and errors via `helpers.handleError`.

## Test plan

- Sign in, navigate between pages, confirm `page_view` events appear in Firebase Analytics DebugView
- Send/accept/decline a friend request — check `friend_request_*` events
- Create a gathering, confirm it, then cancel it — check `gathering_state_changed`
- RSVP to a gathering as a guest — check `gathering_rsvp`
- Add and remove a game from collection — check `game_added/removed_to/from_collection`

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5GLFHS5smsjR4kjcSPBnf)_