### PR TITLE
fix: remove hover interactivity from static feature sections on welcome page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -149,13 +149,6 @@ const features = [
 
 .feature-item {
   border-radius: 8px;
-  transition: all 0.25s ease;
-  border: 1px solid transparent;
-}
-
-.feature-item:hover {
-  background: rgba(200, 134, 10, 0.06);
-  border-color: rgba(200, 134, 10, 0.15);
 }
 
 .feature-title {


### PR DESCRIPTION
The feature sections on the welcome page had a `:hover` CSS rule that added a background highlight and border, making them feel clickable even though they're purely decorative divs with no action attached.

Removed the `.feature-item:hover` block and the now-unused `transition` and `border` properties from `.feature-item`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ptuALJyW3dbmxHKbKQi92)_