### PR TITLE
chore: deploy to bgc.jasonsuttles.dev custom domain

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Generate
         run: yarn run generate
         env:
-          BASE_URL: /board-game-calendar/
+          BASE_URL: /
           NODE_ENV: production
           G_API_KEY: ${{ secrets.G_API_KEY }}
           G_APP_ID: ${{ secrets.G_APP_ID }}
@@ -44,6 +44,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          cname: bgc.jasonsuttles.dev
 
       - name: Deploy database rules to Firebase
         run: |


### PR DESCRIPTION
## Summary

- Changes `BASE_URL` from `/board-game-calendar/` to `/` so all asset paths resolve correctly when the site is served from the custom domain root
- Adds `cname: bgc.jasonsuttles.dev` to the GitHub Pages deploy step so the `CNAME` file is written into `gh-pages` on every deploy

## Why

The site has been moved to `bgc.jasonsuttles.dev` (custom domain on the `digiltronix` org). Without these changes, the deployed build still references `/board-game-calendar/_nuxt/...` paths, causing 404s for all assets when loaded from the domain root.

## Test plan

- [ ] After merge, confirm the CD pipeline completes successfully
- [ ] Visit `http://bgc.jasonsuttles.dev` and confirm the app loads without 404s
- [ ] Once GitHub provisions the TLS cert, enable "Enforce HTTPS" in repo Settings → Pages and confirm `https://bgc.jasonsuttles.dev` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)