### PR TITLE
feat(calendar): add calendar export + email RSVP and calendar links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Fixture data is in `scripts/fixtures/default.json` and mirrors the Firebase RTDB
 - `plugins/firebase.ts` — exports `db`, `auth`, `logEvent`, `log`; uses Firebase 12 modular SDK (`firebase/app`, `/auth`, `/database`, `/analytics`)
 - `plugins/fireauth.client.ts` — Nuxt 4 client-only plugin; awaits first `onAuthStateChanged` callback to hydrate the Pinia store before navigation runs
 - `stores/user.ts` — Pinia store; state: `{ user: User | null }`; actions: `setUser`, `signInWithGoogle`, `signOut`
-- `middleware/auth.global.ts` — Nuxt 4 auto-global route middleware; redirects unauthenticated users to `/signin`, authenticated users away from `/signin`
+- `middleware/auth.global.ts` — Nuxt 4 auto-global route middleware; redirects unauthenticated users to `/signin?redirect={intended fullPath}` (so email RSVP deep-links survive login), authenticated users away from `/signin`. `useAuthSignIn` reads `?redirect` after sign-in (internal paths only, open-redirect-guarded; falls back to `/gamecollection`)
 - `firebase.config.ts` — Firebase credentials (dev vs prod via `NODE_ENV`; committed; public project)
 - `helpers/types.ts` — shared TypeScript types including `FormInstance` for Vuetify 4 form refs
 - `helpers/routes.ts` — route path constants
@@ -75,6 +75,7 @@ Fixture data is in `scripts/fixtures/default.json` and mirrors the Firebase RTDB
 - `helpers/constants.ts` — `LoadingTimeoutInMs`, `DebounceThrottleInMs`, BGG API constants
 - `helpers/helpers.ts` — `handleError()`, HTML entity decoding for BGG API responses
 - `helpers/gatherings.ts` — `splitGatherings`, state/response color+icon maps, `formatDatetime`
+- `helpers/calendar.ts` — calendar-export builders: `googleCalendarUrl()` (Google "new event" template URL), `buildIcs()` (single-VEVENT `.ics`, `PUBLISH`, 3-hour default duration since gatherings store no end time, RFC-5545 escaped, no location since the host address is private), `downloadIcs()` (browser blob download), `toCalendarEventInput()`. The Cloud Functions duplicate this logic server-side (their build has its own `rootDir`, same as `formatDatetime`) — keep both in sync
 - `firebase.json` — Firebase Hosting config
 - `database.rules.json` — Firebase Realtime DB security rules (deployed by `cd.yml` on push to `main`, alongside functions)
 
@@ -183,6 +184,14 @@ BoardGameGeek XML API v2 — proxied via Firebase Cloud Functions (`bggSearch`, 
 - **Authorization is required.** Every request must include an `Authorization: Bearer <token>` header. Tokens are created at https://boardgamegeek.com/applications after registering an application (non-commercial license is free). The token is stored in Secret Manager as `BGG_API_KEY` and accessed via `defineSecret('BGG_API_KEY')` in the Cloud Functions. Requests must go to `boardgamegeek.com` (no `www.` prefix) or the token will not work.
 - Subject to rate limits and occasional 202 "try again" responses
 - Client calls via `httpsCallable` from `firebase/functions`; App Check enforced
+
+## Email notifications & calendar export
+
+Transactional emails are sent server-side from `functions/src/index.ts` via Resend (`RESEND_API_KEY` secret; `FROM_EMAIL`; `APP_URL = https://bgc.jasonsuttles.dev` — keep this current with the deployed domain, it backs every email link). Triggers: `onFriendRequest`, `onGatheringInvite`, `onGatheringStateChange`.
+
+- **Calendar export in-app**: the calendar page renders an "Add to calendar" menu (Google Calendar / Apple·Outlook `.ics`) on every non-canceled hosting and invited card, via `helpers/calendar.ts`.
+- **Calendar in emails**: invite + confirmation emails include an "Add to Google Calendar" link and attach a `.ics` invite (`sendEmail`'s optional `attachments: [{ filename, content }]`, content base64). Cancellation emails get neither.
+- **RSVP from email**: the invite email has Accept/Decline buttons that deep-link to `/calendar?id={gatheringId}&respond=accepted|declined`. The calendar page applies the RSVP on mount once the gathering loads and confirms the user is an invited guest (writes `gatherings/{id}/guests/{uid}` under the existing rules — login required, no new security surface), then strips the query. This relies on the `?redirect` sign-in flow above.
 
 ## Test Setup
 

--- a/composables/useAuthSignIn.ts
+++ b/composables/useAuthSignIn.ts
@@ -14,6 +14,7 @@ import routes from '~/helpers/routes'
 export function useAuthSignIn() {
   const userStore = useUserStore()
   const router = useRouter()
+  const route = useRoute()
   const nuxtApp = useNuxtApp()
   const auth = nuxtApp.$auth
   const db = nuxtApp.$db
@@ -26,6 +27,16 @@ export function useAuthSignIn() {
     helpers.handleError(err)
     errorMessage.value = authErrorMessage(err)
     return false
+  }
+
+  // Honor ?redirect=… set by the auth middleware (e.g. an email RSVP
+  // deep-link), but only for internal paths to avoid an open-redirect.
+  function redirectTarget(): string {
+    const redirect = route.query.redirect
+    if (typeof redirect === 'string' && /^\/(?!\/)/.test(redirect)) {
+      return redirect
+    }
+    return routes.gameCollection
   }
 
   // queryableEmail is validated against the *verified* auth token email by
@@ -67,7 +78,7 @@ export function useAuthSignIn() {
       userStore.setUser(user)
       logEvent('login', { method: provider.providerId })
       await writeProfile(user, user.displayName)
-      await router.push(routes.gameCollection)
+      await router.push(redirectTarget())
       return true
     } catch (err) {
       return fail(err)

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,10 @@
 import { setGlobalOptions } from 'firebase-functions'
 import { onCall, HttpsError } from 'firebase-functions/v2/https'
-import { onValueCreated, onValueUpdated, onValueWritten } from 'firebase-functions/v2/database'
+import {
+  onValueCreated,
+  onValueUpdated,
+  onValueWritten,
+} from 'firebase-functions/v2/database'
 import { defineSecret } from 'firebase-functions/params'
 import { initializeApp } from 'firebase-admin/app'
 import { getAuth } from 'firebase-admin/auth'
@@ -17,7 +21,11 @@ const parseXml = promisify(parseString)
 
 // BGG search only supports a fixed set of item types; allowlist to avoid
 // forwarding arbitrary strings to the upstream API.
-const ALLOWED_BGG_TYPES = new Set(['boardgame', 'boardgameexpansion', 'boardgameaccessory'])
+const ALLOWED_BGG_TYPES = new Set([
+  'boardgame',
+  'boardgameexpansion',
+  'boardgameaccessory',
+])
 
 const BGG_BASE_URL = 'https://boardgamegeek.com/xmlapi2'
 
@@ -58,8 +66,10 @@ export const bggSearch = onCall(
   { enforceAppCheck: true, secrets: [BGG_API_KEY] },
   async (request) => {
     const { query, type } = request.data as { query: string; type: string }
-    if (!query || !type) throw new HttpsError('invalid-argument', 'Missing query or type')
-    if (!ALLOWED_BGG_TYPES.has(type)) throw new HttpsError('invalid-argument', 'Invalid type')
+    if (!query || !type)
+      throw new HttpsError('invalid-argument', 'Missing query or type')
+    if (!ALLOWED_BGG_TYPES.has(type))
+      throw new HttpsError('invalid-argument', 'Invalid type')
 
     const params = new URLSearchParams({ query, type }).toString()
     const url = `${BGG_BASE_URL}/search?${params}`
@@ -68,7 +78,8 @@ export const bggSearch = onCall(
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${BGG_API_KEY.value()}` },
     })
-    if (!response.ok) throw new HttpsError('internal', `BGG error: ${response.statusText}`)
+    if (!response.ok)
+      throw new HttpsError('internal', `BGG error: ${response.statusText}`)
 
     const xml = await response.text()
 
@@ -76,19 +87,29 @@ export const bggSearch = onCall(
     try {
       parsed = await parseXml(xml)
     } catch (err) {
-      console.error('Failed to parse BGG search XML:', err, '\nRaw XML:', xml.slice(0, 500))
+      console.error(
+        'Failed to parse BGG search XML:',
+        err,
+        '\nRaw XML:',
+        xml.slice(0, 500)
+      )
       throw new HttpsError('internal', 'Invalid response from BGG')
     }
 
     // Validate top-level shape before touching nested fields
     const rawItems = (parsed as Record<string, unknown>)?.items
     if (rawItems == null || typeof rawItems !== 'object') {
-      console.error('Unexpected BGG search response shape:', JSON.stringify(parsed)?.slice(0, 500))
+      console.error(
+        'Unexpected BGG search response shape:',
+        JSON.stringify(parsed)?.slice(0, 500)
+      )
       throw new HttpsError('internal', 'Unexpected response format from BGG')
     }
 
     const itemField = (rawItems as Record<string, unknown>).item ?? []
-    const itemArray: unknown[] = Array.isArray(itemField) ? itemField : [itemField]
+    const itemArray: unknown[] = Array.isArray(itemField)
+      ? itemField
+      : [itemField]
 
     const mappedItems = []
     for (const item of itemArray) {
@@ -97,14 +118,19 @@ export const bggSearch = onCall(
       const nameField = (item as Record<string, unknown>)?.name
       const name = attrValue(nameField)
       if (!id || !name) {
-        console.warn('Skipping BGG search item missing id or name:', JSON.stringify(item))
+        console.warn(
+          'Skipping BGG search item missing id or name:',
+          JSON.stringify(item)
+        )
         continue
       }
       mappedItems.push({
         id,
         type: itemType ?? '',
         name,
-        yearpublished: attrValue((item as Record<string, unknown>).yearpublished),
+        yearpublished: attrValue(
+          (item as Record<string, unknown>).yearpublished
+        ),
       })
     }
 
@@ -118,8 +144,11 @@ function parseBggThingItem(item: unknown) {
   if (!itemId) return null
 
   const nameField = itemObj.name
-  const nameArray: unknown[] = Array.isArray(nameField) ? nameField : [nameField]
-  const primaryNameNode = nameArray.find((n) => itemAttr(n, 'type') === 'primary') ?? nameArray[0]
+  const nameArray: unknown[] = Array.isArray(nameField)
+    ? nameField
+    : [nameField]
+  const primaryNameNode =
+    nameArray.find((n) => itemAttr(n, 'type') === 'primary') ?? nameArray[0]
   const name = attrValue(primaryNameNode) ?? ''
 
   const descriptionRaw = first(itemObj.description)
@@ -127,7 +156,8 @@ function parseBggThingItem(item: unknown) {
   const thumbnailRaw = first(itemObj.thumbnail)
 
   const imageUrl = typeof imageRaw === 'string' ? imageRaw : ''
-  const thumbnailUrl = typeof thumbnailRaw === 'string' && thumbnailRaw ? thumbnailRaw : imageUrl
+  const thumbnailUrl =
+    typeof thumbnailRaw === 'string' && thumbnailRaw ? thumbnailRaw : imageUrl
 
   return {
     id: itemId,
@@ -150,7 +180,8 @@ export const bggThing = onCall(
     const { ids } = request.data as { ids: string[] }
     if (!Array.isArray(ids) || ids.length === 0)
       throw new HttpsError('invalid-argument', 'Missing ids')
-    if (ids.length > 20) throw new HttpsError('invalid-argument', 'Too many ids (max 20)')
+    if (ids.length > 20)
+      throw new HttpsError('invalid-argument', 'Too many ids (max 20)')
     if (ids.some((id) => !/^\d+$/.test(id)))
       throw new HttpsError('invalid-argument', 'Invalid id format')
 
@@ -161,7 +192,8 @@ export const bggThing = onCall(
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${BGG_API_KEY.value()}` },
     })
-    if (!response.ok) throw new HttpsError('internal', `BGG error: ${response.statusText}`)
+    if (!response.ok)
+      throw new HttpsError('internal', `BGG error: ${response.statusText}`)
 
     const xml = await response.text()
 
@@ -169,28 +201,41 @@ export const bggThing = onCall(
     try {
       parsed = await parseXml(xml)
     } catch (err) {
-      console.error('Failed to parse BGG thing XML:', err, '\nRaw XML:', xml.slice(0, 500))
+      console.error(
+        'Failed to parse BGG thing XML:',
+        err,
+        '\nRaw XML:',
+        xml.slice(0, 500)
+      )
       throw new HttpsError('internal', 'Invalid response from BGG')
     }
 
     const rawItems = (parsed as Record<string, unknown>)?.items
     if (rawItems == null || typeof rawItems !== 'object') {
-      console.error('Unexpected BGG thing response shape:', JSON.stringify(parsed)?.slice(0, 500))
+      console.error(
+        'Unexpected BGG thing response shape:',
+        JSON.stringify(parsed)?.slice(0, 500)
+      )
       throw new HttpsError('internal', 'Unexpected response format from BGG')
     }
 
     const itemField = (rawItems as Record<string, unknown>).item ?? []
-    const itemArray: unknown[] = Array.isArray(itemField) ? itemField : [itemField]
+    const itemArray: unknown[] = Array.isArray(itemField)
+      ? itemField
+      : [itemField]
 
     const items = itemArray
       .map(parseBggThingItem)
-      .filter((item): item is NonNullable<ReturnType<typeof parseBggThingItem>> => item !== null)
+      .filter(
+        (item): item is NonNullable<ReturnType<typeof parseBggThingItem>> =>
+          item !== null
+      )
 
     return { items }
   }
 )
 
-const APP_URL = 'https://djeisen642.github.io/board-game-calendar'
+const APP_URL = 'https://bgc.jasonsuttles.dev'
 const FROM_EMAIL = 'Board Game Calendar <bgc-notifications@jasonsuttles.dev>'
 
 function escapeHtml(s: string): string {
@@ -202,16 +247,29 @@ function escapeHtml(s: string): string {
     .replace(/'/g, '&#39;')
 }
 
+type EmailAttachment = { filename: string; content: string } // content: base64
+
 // Sends a single email and logs on failure without rethrowing, so one bad
 // address doesn't cause a function retry that re-sends to everyone else.
-async function sendEmail(to: string, subject: string, html: string): Promise<void> {
+async function sendEmail(
+  to: string,
+  subject: string,
+  html: string,
+  attachments?: EmailAttachment[]
+): Promise<void> {
   const res = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${RESEND_API_KEY.value()}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ from: FROM_EMAIL, to, subject, html }),
+    body: JSON.stringify({
+      from: FROM_EMAIL,
+      to,
+      subject,
+      html,
+      ...(attachments?.length ? { attachments } : {}),
+    }),
   })
   if (!res.ok) {
     const body = await res.text()
@@ -232,6 +290,116 @@ function formatDatetime(iso: string, timezone?: string): string {
     timeZoneName: 'short',
     ...(timezone ? { timeZone: timezone } : {}),
   })
+}
+
+// --- Calendar helpers (mirrors helpers/calendar.ts on the client; duplicated
+// because the functions workspace builds from its own rootDir) ---
+
+const GATHERING_DURATION_HOURS = 3
+
+type CalendarEvent = {
+  gatheringId: string
+  datetime: string
+  hostName?: string
+  games?: { name?: string }[]
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function toIcsUtc(date: Date): string {
+  return (
+    String(date.getUTCFullYear()) +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    'T' +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getUTCSeconds()) +
+    'Z'
+  )
+}
+
+function eventEnd(datetime: string): Date {
+  return new Date(
+    new Date(datetime).getTime() + GATHERING_DURATION_HOURS * 60 * 60 * 1000
+  )
+}
+
+function eventTitle(hostName?: string): string {
+  return hostName ? `Board game night with ${hostName}` : 'Board game night'
+}
+
+function eventDescription(event: CalendarEvent): string {
+  const games = (event.games ?? []).map((g) => g.name ?? '').filter(Boolean)
+  const parts: string[] = []
+  if (event.hostName) parts.push(`Hosted by ${event.hostName}.`)
+  if (games.length) parts.push(`Games: ${games.join(', ')}.`)
+  parts.push(`Details: ${APP_URL}/calendar`)
+  return parts.join(' ')
+}
+
+function googleCalendarUrl(event: CalendarEvent): string {
+  const dates = `${toIcsUtc(new Date(event.datetime))}/${toIcsUtc(eventEnd(event.datetime))}`
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: eventTitle(event.hostName),
+    dates,
+    details: eventDescription(event),
+  })
+  return `https://calendar.google.com/calendar/render?${params.toString()}`
+}
+
+function escapeIcs(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r?\n/g, '\\n')
+}
+
+function buildIcs(event: CalendarEvent): string {
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Board Game Calendar//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${event.gatheringId}@bgc.jasonsuttles.dev`,
+    `DTSTAMP:${toIcsUtc(new Date())}`,
+    `DTSTART:${toIcsUtc(new Date(event.datetime))}`,
+    `DTEND:${toIcsUtc(eventEnd(event.datetime))}`,
+    `SUMMARY:${escapeIcs(eventTitle(event.hostName))}`,
+    `DESCRIPTION:${escapeIcs(eventDescription(event))}`,
+    `URL:${APP_URL}/calendar`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n')
+}
+
+function icsAttachment(event: CalendarEvent): EmailAttachment {
+  return {
+    filename: 'board-game-night.ics',
+    content: Buffer.from(buildIcs(event), 'utf-8').toString('base64'),
+  }
+}
+
+// "Add to Google Calendar" link shown beneath the email body.
+function calendarLinkHtml(event: CalendarEvent): string {
+  return `<p><a href="${googleCalendarUrl(event)}">Add to Google Calendar</a> &middot; an Apple/Outlook invite is attached.</p>`
+}
+
+// Accept / Decline buttons that deep-link into the app (the user signs in if
+// needed, then the RSVP is applied on the calendar page).
+function rsvpButtonsHtml(gatheringId: string): string {
+  const accept = `${APP_URL}/calendar?id=${gatheringId}&respond=accepted`
+  const decline = `${APP_URL}/calendar?id=${gatheringId}&respond=declined`
+  return `<p>
+  <a href="${accept}" style="display:inline-block;padding:10px 18px;margin-right:8px;background:#55B855;color:#100A04;text-decoration:none;border-radius:8px;font-weight:600;">Accept</a>
+  <a href="${decline}" style="display:inline-block;padding:10px 18px;background:#E05252;color:#100A04;text-decoration:none;border-radius:8px;font-weight:600;">Decline</a>
+</p>`
 }
 
 async function getProfileName(uid: string): Promise<string> {
@@ -261,12 +429,16 @@ export const onFriendRequest = onValueCreated(
 )
 
 export const onGatheringInvite = onValueWritten(
-  { ref: 'gatherings/{gatheringId}/guests/{guestUid}', secrets: [RESEND_API_KEY] },
+  {
+    ref: 'gatherings/{gatheringId}/guests/{guestUid}',
+    secrets: [RESEND_API_KEY],
+  },
   async (event) => {
     const after = event.data.after.val() as string | null
     const before = event.data.before.val() as string | null
     // Notify on initial invite or re-invite after a decline; skip accept/decline updates
-    if (after !== 'invited' || (before !== null && before !== 'declined')) return
+    if (after !== 'invited' || (before !== null && before !== 'declined'))
+      return
     const { gatheringId, guestUid } = event.params
     const [guestUser, gatheringSnap] = await Promise.all([
       getAuth().getUser(guestUid),
@@ -276,13 +448,25 @@ export const onGatheringInvite = onValueWritten(
     const gathering = gatheringSnap.val() as Record<string, unknown> | null
     if (!gathering) return
     const hostName = await getProfileName(gathering.host as string)
-    const datetime = formatDatetime(gathering.datetime as string, gathering.timezone as string)
+    const datetime = formatDatetime(
+      gathering.datetime as string,
+      gathering.timezone as string
+    )
+    const calEvent: CalendarEvent = {
+      gatheringId,
+      datetime: gathering.datetime as string,
+      hostName,
+      games: gathering.games as { name?: string }[] | undefined,
+    }
     await sendEmail(
       guestUser.email,
       `You're invited to a board game night!`,
       `<p>Hi there,</p>
 <p><strong>${escapeHtml(hostName)}</strong> has invited you to a board game night on <strong>${escapeHtml(datetime)}</strong>.</p>
-<p><a href="${APP_URL}/calendar">View on your calendar</a></p>`
+${rsvpButtonsHtml(gatheringId)}
+<p><a href="${APP_URL}/calendar">View on your calendar</a></p>
+${calendarLinkHtml(calEvent)}`,
+      [icsAttachment(calEvent)]
     )
   }
 )
@@ -295,33 +479,57 @@ export const onGatheringStateChange = onValueUpdated(
     if (newState === oldState) return
     if (newState !== 'confirmed' && newState !== 'canceled') return
     const { gatheringId } = event.params
-    const gatheringSnap = await getDatabase().ref(`gatherings/${gatheringId}`).get()
+    const gatheringSnap = await getDatabase()
+      .ref(`gatherings/${gatheringId}`)
+      .get()
     const gathering = gatheringSnap.val() as Record<string, unknown> | null
     if (!gathering) return
     const guests = (gathering.guests as Record<string, string> | null) ?? {}
     // Notify accepted guests on confirm; notify accepted + invited guests on cancel
     const notifyUids = Object.entries(guests)
-      .filter(([, status]) => status === 'accepted' || (newState === 'canceled' && status === 'invited'))
+      .filter(
+        ([, status]) =>
+          status === 'accepted' ||
+          (newState === 'canceled' && status === 'invited')
+      )
       .map(([uid]) => uid)
     if (notifyUids.length === 0) return
     const [hostName, guestUsers] = await Promise.all([
       getProfileName(gathering.host as string),
       Promise.all(notifyUids.map((uid) => getAuth().getUser(uid))),
     ])
-    const datetime = formatDatetime(gathering.datetime as string, gathering.timezone as string)
+    const datetime = formatDatetime(
+      gathering.datetime as string,
+      gathering.timezone as string
+    )
     const subject =
       newState === 'confirmed'
         ? `Game night confirmed: ${datetime}`
         : `Game night canceled: ${datetime}`
     const safeHost = escapeHtml(hostName)
     const safeDatetime = escapeHtml(datetime)
+    const calEvent: CalendarEvent = {
+      gatheringId,
+      datetime: gathering.datetime as string,
+      hostName,
+      games: gathering.games as { name?: string }[] | undefined,
+    }
     const html =
       newState === 'confirmed'
         ? `<p>Great news! <strong>${safeHost}</strong> has confirmed the board game night on <strong>${safeDatetime}</strong>.</p>
-<p><a href="${APP_URL}/calendar">View on your calendar</a></p>`
+<p><a href="${APP_URL}/calendar">View on your calendar</a></p>
+${calendarLinkHtml(calEvent)}`
         : `<p><strong>${safeHost}</strong> has unfortunately canceled the board game night on <strong>${safeDatetime}</strong>.</p>
 <p><a href="${APP_URL}/calendar">View your calendar</a></p>`
-    const emails = guestUsers.map((u) => u.email).filter((e): e is string => !!e)
-    await Promise.all(emails.map((email) => sendEmail(email, subject, html)))
+    // Attach the .ics only on confirm — there's nothing to add to a calendar
+    // for a cancellation.
+    const attachments =
+      newState === 'confirmed' ? [icsAttachment(calEvent)] : undefined
+    const emails = guestUsers
+      .map((u) => u.email)
+      .filter((e): e is string => !!e)
+    await Promise.all(
+      emails.map((email) => sendEmail(email, subject, html, attachments))
+    )
   }
 )

--- a/helpers/calendar.ts
+++ b/helpers/calendar.ts
@@ -1,0 +1,128 @@
+import type { Gathering } from './types'
+
+// Game nights have no explicit end time stored, so calendar events default to a
+// fixed-length block starting at the gathering's datetime.
+export const GATHERING_DURATION_HOURS = 3
+
+export type CalendarEventInput = {
+  gatheringId: string
+  datetime: string // ISO date (UTC)
+  hostName?: string
+  games?: { name: string }[]
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+// RFC 5545 UTC timestamp: YYYYMMDDTHHMMSSZ
+function toIcsUtc(date: Date): string {
+  return (
+    String(date.getUTCFullYear()) +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    'T' +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getUTCSeconds()) +
+    'Z'
+  )
+}
+
+function endDate(datetime: string): Date {
+  return new Date(
+    new Date(datetime).getTime() + GATHERING_DURATION_HOURS * 60 * 60 * 1000
+  )
+}
+
+export function eventTitle(hostName?: string): string {
+  return hostName ? `Board game night with ${hostName}` : 'Board game night'
+}
+
+export function eventDescription(
+  input: CalendarEventInput,
+  appUrl: string
+): string {
+  const games = (input.games ?? []).map((g) => g.name).filter(Boolean)
+  const parts: string[] = []
+  if (input.hostName) parts.push(`Hosted by ${input.hostName}.`)
+  if (games.length) parts.push(`Games: ${games.join(', ')}.`)
+  parts.push(`Details: ${appUrl}/calendar`)
+  return parts.join(' ')
+}
+
+// Google Calendar event-template URL (opens a pre-filled "new event" page).
+export function googleCalendarUrl(
+  input: CalendarEventInput,
+  appUrl: string
+): string {
+  const start = new Date(input.datetime)
+  const dates = `${toIcsUtc(start)}/${toIcsUtc(endDate(input.datetime))}`
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: eventTitle(input.hostName),
+    dates,
+    details: eventDescription(input, appUrl),
+  })
+  return `https://calendar.google.com/calendar/render?${params.toString()}`
+}
+
+// Escape a value for an RFC 5545 text field.
+function escapeIcs(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r?\n/g, '\\n')
+}
+
+// A single-event VCALENDAR (METHOD:PUBLISH) for download / email attachment.
+// Imports into Apple Calendar, Outlook, Google Calendar, etc.
+export function buildIcs(input: CalendarEventInput, appUrl: string): string {
+  const start = new Date(input.datetime)
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Board Game Calendar//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${input.gatheringId}@bgc.jasonsuttles.dev`,
+    `DTSTAMP:${toIcsUtc(new Date())}`,
+    `DTSTART:${toIcsUtc(start)}`,
+    `DTEND:${toIcsUtc(endDate(input.datetime))}`,
+    `SUMMARY:${escapeIcs(eventTitle(input.hostName))}`,
+    `DESCRIPTION:${escapeIcs(eventDescription(input, appUrl))}`,
+    `URL:${appUrl}/calendar`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ]
+  return lines.join('\r\n')
+}
+
+export function toCalendarEventInput(
+  gathering: Gathering & { id: string },
+  hostName?: string
+): CalendarEventInput {
+  return {
+    gatheringId: gathering.id,
+    datetime: gathering.datetime,
+    hostName,
+    games: gathering.games,
+  }
+}
+
+// Triggers a browser download of an .ics file (Apple Calendar / Outlook).
+export function downloadIcs(input: CalendarEventInput, appUrl: string): void {
+  const blob = new Blob([buildIcs(input, appUrl)], {
+    type: 'text/calendar;charset=utf-8',
+  })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `board-game-night-${input.gatheringId}.ics`
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(url)
+}

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -12,6 +12,8 @@ export default defineNuxtRouteMiddleware((to) => {
     to.name &&
     ![names.index, names.signIn].includes(to.name as string)
   ) {
-    return navigateTo(routes.signIn)
+    // Preserve the intended destination (incl. query, e.g. email RSVP
+    // deep-links) so sign-in can return the user there.
+    return navigateTo({ path: routes.signIn, query: { redirect: to.fullPath } })
   }
 })

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -111,6 +111,31 @@
                 >
                   <v-icon start>mdi-check-circle</v-icon>Confirm
                 </v-btn>
+                <v-menu v-if="gathering.state !== 'canceled'">
+                  <template #activator="{ props }">
+                    <v-btn
+                      v-bind="props"
+                      density="compact"
+                      size="small"
+                      variant="text"
+                      color="accent"
+                    >
+                      <v-icon start>mdi-calendar-export</v-icon>Add to calendar
+                    </v-btn>
+                  </template>
+                  <v-list density="compact">
+                    <v-list-item
+                      prepend-icon="mdi-google"
+                      title="Google Calendar"
+                      @click="addToGoogle(gathering)"
+                    />
+                    <v-list-item
+                      prepend-icon="mdi-calendar-arrow-right"
+                      title="Apple / Outlook (.ics)"
+                      @click="addToApple(gathering)"
+                    />
+                  </v-list>
+                </v-menu>
                 <v-btn
                   v-if="gathering.state !== 'canceled'"
                   density="compact"
@@ -205,6 +230,31 @@
                 >
                   <v-icon start>mdi-close-circle</v-icon>Decline
                 </v-btn>
+                <v-menu>
+                  <template #activator="{ props }">
+                    <v-btn
+                      v-bind="props"
+                      density="compact"
+                      size="small"
+                      variant="text"
+                      color="accent"
+                    >
+                      <v-icon start>mdi-calendar-export</v-icon>Add to calendar
+                    </v-btn>
+                  </template>
+                  <v-list density="compact">
+                    <v-list-item
+                      prepend-icon="mdi-google"
+                      title="Google Calendar"
+                      @click="addToGoogle(gathering)"
+                    />
+                    <v-list-item
+                      prepend-icon="mdi-calendar-arrow-right"
+                      title="Apple / Outlook (.ics)"
+                      @click="addToApple(gathering)"
+                    />
+                  </v-list>
+                </v-menu>
               </div>
             </div>
           </template>
@@ -230,12 +280,18 @@ import {
   formatDatetime,
   type GatheringWithId,
 } from '~/helpers/gatherings'
+import {
+  googleCalendarUrl,
+  downloadIcs,
+  toCalendarEventInput,
+} from '~/helpers/calendar'
 import type { Gathering, GatheringState, GuestResponse } from '~/helpers/types'
 
 useHead({ title: 'Calendar' })
 
 const userStore = useUserStore()
 const router = useRouter()
+const route = useRoute()
 const nuxtApp = useNuxtApp()
 const db = nuxtApp.$db
 const logEvent = nuxtApp.$logEvent
@@ -250,6 +306,39 @@ const gatheringListeners = new Map<string, () => void>()
 
 const uid = userStore.user!.uid
 const { names, resolveNames, guestEntries } = useGatheringDisplay()
+
+// Email "Accept"/"Decline" buttons deep-link here as
+// /calendar?id={gatheringId}&respond=accepted|declined. The RSVP is applied
+// once the gathering loads and we confirm the user is one of its invited guests.
+const pendingRsvp = ref<{ id: string; response: GuestResponse } | null>(null)
+
+function appUrl(): string {
+  return window.location.origin
+}
+
+function calendarInput(gathering: GatheringWithId) {
+  return toCalendarEventInput(gathering, names.value[gathering.host])
+}
+
+function addToGoogle(gathering: GatheringWithId) {
+  window.open(
+    googleCalendarUrl(calendarInput(gathering), appUrl()),
+    '_blank',
+    'noopener'
+  )
+  logEvent('gathering_add_to_calendar', { provider: 'google' })
+}
+
+function addToApple(gathering: GatheringWithId) {
+  downloadIcs(calendarInput(gathering), appUrl())
+  logEvent('gathering_add_to_calendar', { provider: 'ics' })
+}
+
+function clearRsvpQuery() {
+  if (route.query.respond || route.query.id) {
+    void router.replace({ path: routes.calendar })
+  }
+}
 
 function dropGathering(id: string) {
   const { [id]: _gone, ...rest } = gatheringsById.value
@@ -277,6 +366,14 @@ function watchGathering(id: string) {
 }
 
 onMounted(() => {
+  const respondParam = route.query.respond
+  const idParam = route.query.id
+  if (
+    (respondParam === 'accepted' || respondParam === 'declined') &&
+    typeof idParam === 'string'
+  ) {
+    pendingRsvp.value = { id: idParam, response: respondParam }
+  }
   unsubscribeIndex = onValue(
     dbRef(db, `userGatherings/${uid}`),
     (snapshot) => {
@@ -322,6 +419,39 @@ const invited = computed(() => sections.value.invited)
 
 watch(sections, (value) => {
   void resolveNames(value)
+})
+
+// Apply an email-deep-linked RSVP once its gathering has loaded. Fires when
+// gatherings arrive (or when the intent is first set).
+watch([gatheringsById, pendingRsvp], async () => {
+  const intent = pendingRsvp.value
+  if (!intent) return
+  const gathering = gatheringsById.value[intent.id]
+  if (!gathering) return // not loaded yet (or the user isn't a participant)
+  // Only invited guests can RSVP; hosts and non-invitees are ignored.
+  if (gathering.host === uid || !(uid in (gathering.guests ?? {}))) {
+    pendingRsvp.value = null
+    clearRsvpQuery()
+    return
+  }
+  const { response } = intent
+  pendingRsvp.value = null // clear before awaiting to avoid re-entry
+  if (gathering.state === 'canceled') {
+    snackbar.value?.showSnackbarWithMessage(
+      'This gathering has been canceled.',
+      true
+    )
+    clearRsvpQuery()
+    return
+  }
+  await respond({ id: intent.id, ...gathering }, response)
+  snackbar.value?.showSnackbarWithMessage(
+    response === 'accepted'
+      ? 'You accepted the invitation.'
+      : 'You declined the invitation.',
+    false
+  )
+  clearRsvpQuery()
 })
 
 function myResponse(gathering: Gathering): GuestResponse | undefined {

--- a/test/calendar.spec.ts
+++ b/test/calendar.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import {
+  eventTitle,
+  eventDescription,
+  googleCalendarUrl,
+  buildIcs,
+  type CalendarEventInput,
+} from '~/helpers/calendar'
+
+const APP_URL = 'https://bgc.jasonsuttles.dev'
+
+// 2026-07-01 19:00 UTC; +3h default duration => 22:00 UTC
+const event: CalendarEventInput = {
+  gatheringId: 'abc123',
+  datetime: '2026-07-01T19:00:00.000Z',
+  hostName: 'Alex Johnson',
+  games: [{ name: 'Catan' }, { name: 'Wingspan' }],
+}
+
+describe('eventTitle', () => {
+  it('includes the host name when present', () => {
+    expect(eventTitle('Alex Johnson')).toBe(
+      'Board game night with Alex Johnson'
+    )
+  })
+
+  it('falls back to a generic title without a host', () => {
+    expect(eventTitle()).toBe('Board game night')
+  })
+})
+
+describe('eventDescription', () => {
+  it('lists host, games, and a details link', () => {
+    const desc = eventDescription(event, APP_URL)
+    expect(desc).toContain('Hosted by Alex Johnson.')
+    expect(desc).toContain('Games: Catan, Wingspan.')
+    expect(desc).toContain(`${APP_URL}/calendar`)
+  })
+})
+
+describe('googleCalendarUrl', () => {
+  it('builds a TEMPLATE url with a UTC start/end range', () => {
+    const url = googleCalendarUrl(event, APP_URL)
+    expect(url).toContain('https://calendar.google.com/calendar/render?')
+    expect(url).toContain('action=TEMPLATE')
+    // dates=20260701T190000Z/20260701T220000Z (url-encoded slash)
+    expect(decodeURIComponent(url)).toContain(
+      'dates=20260701T190000Z/20260701T220000Z'
+    )
+  })
+})
+
+describe('buildIcs', () => {
+  it('produces a single VEVENT with correct UTC times and CRLF lines', () => {
+    const ics = buildIcs(event, APP_URL)
+    expect(ics).toContain('BEGIN:VCALENDAR')
+    expect(ics).toContain('BEGIN:VEVENT')
+    expect(ics).toContain('UID:abc123@bgc.jasonsuttles.dev')
+    expect(ics).toContain('DTSTART:20260701T190000Z')
+    expect(ics).toContain('DTEND:20260701T220000Z')
+    expect(ics).toContain('SUMMARY:Board game night with Alex Johnson')
+    expect(ics).toContain('END:VCALENDAR')
+    expect(ics).toContain('\r\n')
+  })
+
+  it('escapes commas in the description per RFC 5545', () => {
+    const ics = buildIcs(event, APP_URL)
+    expect(ics).toContain('Catan\\, Wingspan')
+  })
+})


### PR DESCRIPTION
## Summary

Adds calendar integration end-to-end: in-app "Add to calendar" (Google / Apple·Outlook), calendar attachments + links in the notification emails, and one-tap Accept/Decline from the invite email.

## What's included

### In-app calendar export
- New `helpers/calendar.ts`: `googleCalendarUrl()` (Google "new event" template URL), `buildIcs()` (single-VEVENT `.ics`, `METHOD:PUBLISH`, 3-hour default duration since gatherings store no end time, RFC-5545 escaped, no location since the host address is private), and `downloadIcs()`.
- An "Add to calendar" menu (Google Calendar / Apple·Outlook `.ics`) on every non-canceled **Hosting** and **Invited** card on the calendar page.

### Calendar in the emails
- Invite + confirmation emails now attach a `.ics` invite and include an "Add to Google Calendar" link (`sendEmail` gained optional `attachments`). Cancellation emails get neither.
- The server mirrors `helpers/calendar.ts` (the functions workspace builds from its own `rootDir`, same pattern as the existing duplicated `formatDatetime`).

### Accept / Decline from email
- The invite email has **Accept** / **Decline** buttons that deep-link to `/calendar?id={gatheringId}&respond=accepted|declined`.
- The calendar page applies the RSVP on mount once the gathering loads and the user is confirmed an invited guest, writing `gatherings/{id}/guests/{uid}` under the existing security rules (login required, no new backend surface), then strips the query.
- To make deep-links survive login, the auth middleware passes `?redirect=` and `useAuthSignIn` honors it (internal paths only, open-redirect-guarded).

### Fix
- The functions `APP_URL` still pointed at the old GitHub Pages address (`djeisen642.github.io/board-game-calendar`); updated to `https://bgc.jasonsuttles.dev` so every email link — including the new RSVP deep-links — resolves.

## Testing
- `yarn test` — passes (new `test/calendar.spec.ts` covers title/description/Google URL/ICS).
- `yarn lint` — passes.
- `functions` `tsc` build — passes.
- Screenshot of `/calendar` confirms the buttons render in-theme.

## Notes
- The `.ics` uses `METHOD:PUBLISH` (plain "add to calendar") rather than `METHOD:REQUEST` (native Gmail/Apple Mail RSVP chrome), since RSVP is handled by the app's Accept/Decline buttons. Easy to switch if native mail-client RSVP is preferred later.
- Email changes take effect on the next functions deploy (`cd.yml` on push to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)