### PR TITLE
fix(functions): run as scoped firebase-adminsdk SA (least privilege)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,9 +443,17 @@ GitHub Actions (`.github/workflows/cd.yml`) runs `yarn generate` and deploys `di
 
 ### Cloud Functions service accounts (important)
 
-The functions **must not** pin a custom `serviceAccount` in `setGlobalOptions`. The 2nd-gen RTDB→Eventarc triggers (`onFriendRequest`, `onGatheringInvite`, `onGatheringStateChange`) run as their service account, which must hold `roles/eventarc.eventReceiver` to receive events. The project's **default compute SA** (`<projectNumber>-compute@developer.gserviceaccount.com`) already has it; the previously-pinned `firebase-adminsdk-fbsvc@…` SA did **not**, so deploys failed trigger validation with `Permission 'eventarc.events.receiveEvent' denied`. Leaving `serviceAccount` unset is the fix — don't re-add it.
+The functions pin a scoped runtime SA in `setGlobalOptions`: `serviceAccount: 'firebase-adminsdk-fbsvc@…'`. This is deliberate, for **least privilege** — if `serviceAccount` is unset, functions run as the project's default compute SA (`<projectNumber>-compute@…`), which carries the broad `roles/editor`. The scoped SA already has the RTDB read + Firebase Auth access the functions need.
 
-Secret access (`BGG_API_KEY`, `RESEND_API_KEY`) is auto-granted to the runtime SA at deploy time; this works in CD because the `github-action-…` deployer SA has `secretmanager.admin` and project-level `iam.serviceAccountUser` (so it can grant secrets and `actAs` the compute SA). Each trigger also pins `instance: 'board-game-calendar-3ae94-default-rtdb'` so the RTDB instance is unambiguous.
+The 2nd-gen RTDB→Eventarc triggers (`onFriendRequest`, `onGatheringInvite`, `onGatheringStateChange`) run as that SA, which **must hold `roles/eventarc.eventReceiver`** or deploys fail trigger validation with `Permission 'eventarc.events.receiveEvent' denied`. This is a one-time, persistent grant (CD never touches IAM):
+
+```bash
+gcloud projects add-iam-policy-binding board-game-calendar-3ae94 \
+  --member="serviceAccount:firebase-adminsdk-fbsvc@board-game-calendar-3ae94.iam.gserviceaccount.com" \
+  --role="roles/eventarc.eventReceiver"
+```
+
+Secret access (`BGG_API_KEY`, `RESEND_API_KEY`) is auto-granted to the runtime SA at deploy time; this works in CD because the `github-action-…` deployer SA has `secretmanager.admin` and project-level `iam.serviceAccountUser` (so it can grant secrets and `actAs` the runtime SA). Each trigger also pins `instance: 'board-game-calendar-3ae94-default-rtdb'` so the RTDB instance is unambiguous.
 
 ### Cloud Functions dependencies — no lockfile, pin exact (important)
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -29,17 +29,23 @@ const ALLOWED_BGG_TYPES = new Set([
 
 const BGG_BASE_URL = 'https://boardgamegeek.com/xmlapi2'
 
-// Do NOT pin a custom `serviceAccount` here. The 2nd-gen RTDB→Eventarc triggers
-// below run as this SA, which must hold roles/eventarc.eventReceiver to receive
-// events. The project's default compute SA already has it; a custom SA
-// (firebase-adminsdk-fbsvc) did not, which made `firebase deploy --only
-// functions` fail trigger validation with "Permission 'eventarc.events.
-// receiveEvent' denied". Leaving it unset lets the functions run as the default
-// compute SA. Secret access (BGG_API_KEY, RESEND_API_KEY) is auto-granted to the
-// runtime SA at deploy time, by both local owner deploys and the CD deployer
-// (the github-action SA has secretmanager.admin + project iam.serviceAccountUser).
+// The 2nd-gen RTDB→Eventarc triggers below run as this service account. We pin
+// the scoped firebase-adminsdk SA for least privilege — the project's default
+// compute SA carries the broad roles/editor, which we don't want functions
+// running as. firebase-adminsdk-fbsvc already has the RTDB read + Firebase Auth
+// access these functions need, and secret access (BGG_API_KEY, RESEND_API_KEY)
+// is auto-granted at deploy time.
+//
+// ONE-TIME SETUP: this SA must hold roles/eventarc.eventReceiver or deploys fail
+// trigger validation with "Permission 'eventarc.events.receiveEvent' denied".
+// It's a persistent grant (CD never touches IAM), so run it once:
+//   gcloud projects add-iam-policy-binding board-game-calendar-3ae94 \
+//     --member="serviceAccount:firebase-adminsdk-fbsvc@board-game-calendar-3ae94.iam.gserviceaccount.com" \
+//     --role="roles/eventarc.eventReceiver"
 setGlobalOptions({
   maxInstances: 5,
+  serviceAccount:
+    'firebase-adminsdk-fbsvc@board-game-calendar-3ae94.iam.gserviceaccount.com',
 })
 
 // xml2js wraps repeated XML elements as arrays but single occurrences as plain


### PR DESCRIPTION
Follow-up to #485, which merged the **compute-SA** version before the least-privilege revert landed. `main` currently runs all functions as the default compute SA, which carries project-wide `roles/editor`. This re-pins the scoped `firebase-adminsdk-fbsvc` SA so functions run with only the RTDB-read + Firebase-Auth access they need.

## Required before/with merge (one-time, run by an owner)

```bash
# 1. Grant the scoped runtime SA the Eventarc role, or the deploy fails trigger validation
gcloud projects add-iam-policy-binding board-game-calendar-3ae94 \
  --member="serviceAccount:firebase-adminsdk-fbsvc@board-game-calendar-3ae94.iam.gserviceaccount.com" \
  --role="roles/eventarc.eventReceiver"

# 2. Delete the orphaned FAILED function (this is what's failing the current CD run:
#    "Changing from an HTTPS function to a background triggered function is not allowed")
gcloud functions delete onFriendRequest --gen2 --region=us-central1 --quiet
```

Without step 1 the deploy fails with `Permission 'eventarc.events.receiveEvent' denied`; without step 2 it fails with the HTTPS→background conversion error seen in the last CD run. Both are one-time.

## Why scoped over compute SA

The compute SA has `roles/editor` — a bug in any function would have project-wide write. `firebase-adminsdk-fbsvc` is scoped to Firebase services and already has the data access these functions use (RTDB reads, `auth.getUser`); secret access is auto-granted at deploy. The `eventReceiver` grant is a persistent IAM binding — CD never touches IAM, so it's not fragile.

## Verification
- `functions` `tsc` build passes; comment + CLAUDE.md updated so the override isn't removed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)