### PR TITLE
Readable serif type + roomier calendar cards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,14 +230,24 @@ The app uses a consistent **"Evening Game Table"** design system: a deep green f
 
 ### Typography
 
-- Headings: **Cinzel** (serif) via `$heading-font-family` in `variables.scss`
-- Body: **Lora** (serif) via `$body-font-family`
+- Headings / display: **Fraunces** (serif) via `$heading-font-family` in `variables.scss`. A warm "old-style" serif loaded as a **variable font with its optical-size axis** (`opsz` `9..144`, weights 400/600/700) — the browser auto-renders small text with the legible *text* cut and large titles with the expressive *display* cut. Replaced Cinzel (a caps-only inscriptional face that was illegible on small all-caps chrome).
+- Body: **Lora** (serif) via `$body-font-family`. Also used on **chips/status tokens** (not the display face) so small tokens stay readable.
 - Body text color: `#E8D4A8` (Vuetify `on-surface`)
-- Page title: `.page-title` → `1.35rem / 700`, Cinzel, rendered as `<h1>` (not `<span>`)
-- Section label: `.section-label` → `0.8rem / 600`, uppercase, `#c8860a` (full opacity); auto-prefixed with a small amber diamond "scoring marker" via `::before` (flex row)
-- Empty state title: `.empty-title` → `1.2rem / 600`, Cinzel
+- Page title: `.page-title` → `1.4rem / 700`, Fraunces, `letter-spacing: 0.01em`, rendered as `<h1>` (not `<span>`)
+- Section label: `.section-label` → `0.82rem / 600`, Fraunces, uppercase, `letter-spacing: 0.1em`, `#c8860a` (full opacity); auto-prefixed with a small amber diamond "scoring marker" via `::before` (flex row)
+- Empty state title: `.empty-title` → `1.25rem / 600`, Fraunces
 - Empty state description: `.empty-desc` → `0.95rem`, Lora, `rgba(240,223,196,0.80)`
-- All buttons: `text-transform: none`, `font-family: Cinzel`, `letter-spacing: 0.06em` (global override in `global.scss`)
+- All buttons: `text-transform: none`, `font-family: Fraunces`, `letter-spacing: 0.01em` (global override in `global.scss`)
+- Chips: `font-family: Lora`, `0.78rem / 600`, `letter-spacing: 0.01em` (global override in `global.scss`) — deliberately the body serif, not the display face. **Keep tracking minimal**; the old wide letter-spacing existed only to space out Cinzel's caps.
+
+> **Why Fraunces, not Cinzel:** Cinzel has no real lowercase, so it force-capped everything; on small chips/buttons/labels that read as illegible. Fraunces has true lowercase, a full weight range, and an optical-size axis, so it keeps the warm antique tabletop character while reading cleanly at every size. When adding new display text, prefer Fraunces with minimal letter-spacing; reserve uppercase for short single-word labels only.
+
+### UI copy (capitalization)
+
+All UI labels use **sentence case** — capitalize only the first word: buttons ("Add game", "Create gathering", "Sign in"), nav items, menu items, page titles (`.page-title` h1 and `useHead({ title })`), section labels, field labels/placeholders, and status text. This is the Material Design / Vuetify default.
+
+- **Exceptions — keep their own casing:** proper nouns (the "Board Game Calendar" brand and "BGC", product names like "Google Calendar" and "Apple / Outlook", "BoardGameGeek"/"BGG"), game names, and people's names.
+- This convention only became visible once the display font changed to Fraunces (Cinzel rendered everything as caps, hiding casing). When adding any new label, default to sentence case.
 
 ### Spacing & shape
 

--- a/assets/global.scss
+++ b/assets/global.scss
@@ -75,10 +75,10 @@ body::after {
 
 // ── Page utility classes ──────────────────────────────────────────────────────
 .page-title {
-  font-family: 'Cinzel', Georgia, serif;
-  font-size: 1.35rem;
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 1.4rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.01em;
   color: #f0dfc4;
   margin: 0;
   line-height: inherit;
@@ -88,11 +88,11 @@ body::after {
   display: flex;
   align-items: center;
   gap: 9px;
-  font-family: 'Cinzel', Georgia, serif;
-  font-size: 0.8rem;
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 0.82rem;
   color: #c8860a;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.1em;
   font-weight: 600;
   animation: slide-in 0.4s ease both;
 
@@ -123,8 +123,8 @@ body::after {
 }
 
 .empty-title {
-  font-family: 'Cinzel', Georgia, serif;
-  font-size: 1.2rem;
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 1.25rem;
   font-weight: 600;
   color: rgba(240, 223, 196, 0.9);
   letter-spacing: 0.04em;
@@ -256,9 +256,9 @@ body::after {
 // ── Buttons — Game piece style ────────────────────────────────────────────────
 .v-btn {
   text-transform: none !important;
-  font-family: 'Cinzel', Georgia, serif !important;
+  font-family: 'Fraunces', Georgia, serif !important;
   font-weight: 600 !important;
-  letter-spacing: 0.06em !important;
+  letter-spacing: 0.01em !important;
   border-radius: 10px !important;
   transition: all 0.2s ease !important;
 
@@ -349,9 +349,9 @@ body::after {
 // Status chips read like little wooden disc tokens placed on the card: a soft
 // raised highlight on top, a contact shadow below.
 .v-chip {
-  font-family: 'Cinzel', Georgia, serif !important;
-  font-size: 0.72rem !important;
-  letter-spacing: 0.07em !important;
+  font-family: 'Lora', Georgia, serif !important;
+  font-size: 0.78rem !important;
+  letter-spacing: 0.01em !important;
   font-weight: 600 !important;
   box-shadow:
     inset 0 1px 0 rgba(240, 223, 196, 0.12),
@@ -404,7 +404,7 @@ body::after {
   color: #100A04;
   padding: 8px 16px;
   z-index: 9999;
-  font-family: 'Cinzel', Georgia, serif;
+  font-family: 'Fraunces', Georgia, serif;
   font-weight: 600;
   font-size: 0.9rem;
   text-decoration: none;

--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -4,7 +4,7 @@
 
 // Typography — board game serif stack
 $body-font-family: 'Lora', Georgia, serif;
-$heading-font-family: 'Cinzel', Georgia, serif;
+$heading-font-family: 'Fraunces', Georgia, serif;
 
 // Border radius — soft, modern card feel
 $border-radius-root: 10px;

--- a/components/GameSearch.vue
+++ b/components/GameSearch.vue
@@ -8,7 +8,7 @@
       :loading="isLoading"
       item-title="displayname"
       item-value="id"
-      label="Board Game Search"
+      label="Board game search"
       placeholder="Start typing to search"
       :hint="`Type at least ${constants.MinSearchLength} characters`"
       prepend-icon="mdi-database-search"
@@ -21,7 +21,11 @@
       <v-list-item v-for="(item, i) in entriesToShow" :key="i">
         <template #prepend>
           <v-avatar rounded="0" size="56" color="surface-variant">
-            <v-img v-if="item.thumbnail" :src="item.thumbnail" :alt="item.name" />
+            <v-img
+              v-if="item.thumbnail"
+              :src="item.thumbnail"
+              :alt="item.name"
+            />
             <v-icon v-else size="32">mdi-gamepad-variant-outline</v-icon>
           </v-avatar>
         </template>

--- a/error.vue
+++ b/error.vue
@@ -19,7 +19,7 @@
             }}
           </p>
           <v-btn color="primary" variant="elevated" to="/">
-            <v-icon start>mdi-home</v-icon>Go Home
+            <v-icon start>mdi-home</v-icon>Go home
           </v-btn>
         </v-col>
       </v-row>
@@ -33,7 +33,7 @@ defineProps<{ error: { statusCode?: number; message?: string } }>()
 
 <style scoped>
 .error-code {
-  font-family: 'Cinzel', Georgia, serif;
+  font-family: 'Fraunces', Georgia, serif;
   font-size: 3.25rem;
   font-weight: 700;
   letter-spacing: 0.04em;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -21,7 +21,10 @@
     </v-navigation-drawer>
 
     <v-app-bar class="bgc-app-bar" flat>
-      <v-app-bar-nav-icon aria-label="Open navigation menu" @click.stop="drawer = !drawer" />
+      <v-app-bar-nav-icon
+        aria-label="Open navigation menu"
+        @click.stop="drawer = !drawer"
+      />
       <v-toolbar-title class="app-bar-title">
         <v-icon class="app-bar-title-icon" color="primary" size="20"
           >mdi-hexagon-multiple</v-icon
@@ -92,7 +95,7 @@ const items = [
   },
   {
     icon: 'mdi-account-key',
-    title: 'Sign In',
+    title: 'Sign in',
     to: routes.signIn,
     type: PageType.BeforeAuth,
   },
@@ -104,13 +107,13 @@ const items = [
   },
   {
     icon: 'mdi-dice-multiple',
-    title: 'New Gathering',
+    title: 'New gathering',
     to: routes.newGathering,
     type: PageType.NeedsAuth,
   },
   {
     icon: 'mdi-cards-outline',
-    title: 'Game Collection',
+    title: 'Game collection',
     to: routes.gameCollection,
     type: PageType.NeedsAuth,
   },
@@ -157,7 +160,7 @@ async function onSignoutClicked() {
 }
 
 .drawer-brand {
-  font-family: 'Cinzel', Georgia, serif;
+  font-family: 'Fraunces', Georgia, serif;
   font-size: 1.1rem;
   font-weight: 700;
   letter-spacing: 0.12em;
@@ -166,7 +169,7 @@ async function onSignoutClicked() {
 }
 
 .app-bar-title {
-  font-family: 'Cinzel', Georgia, serif;
+  font-family: 'Fraunces', Georgia, serif;
   font-weight: 600;
   letter-spacing: 0.06em;
   color: #f0dfc4;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -56,7 +56,7 @@ export default defineNuxtConfig({
         {
           rel: 'preload',
           as: 'style',
-          href: 'https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Lora:ital,wght@0,400;0,600;1,400&display=swap',
+          href: 'https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Lora:ital,wght@0,400;0,600;1,400&display=swap',
           onload: "this.onload=null;this.rel='stylesheet'",
         },
       ],

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -41,7 +41,7 @@
               class="mt-4"
               :to="routes.newGathering"
             >
-              <v-icon start>mdi-calendar-plus</v-icon>New Gathering
+              <v-icon start>mdi-calendar-plus</v-icon>New gathering
             </v-btn>
           </div>
         </v-card-text>
@@ -51,9 +51,9 @@
             <div
               v-for="gathering in hosting"
               :key="gathering.id"
-              class="event-item pa-4 mb-3"
+              class="event-item pa-5 mb-4"
             >
-              <div class="d-flex align-center flex-wrap gap-2 mb-3">
+              <div class="d-flex align-center flex-wrap gap-3 mb-3">
                 <v-chip
                   :color="stateColor(gathering.state)"
                   size="small"
@@ -66,7 +66,7 @@
                   >{{ formatDatetime(gathering.datetime) }}</span
                 >
               </div>
-              <div v-if="gathering.games?.length" class="event-line mb-2">
+              <div v-if="gathering.games?.length" class="event-line mb-3">
                 <v-icon size="16" class="mr-1">mdi-rhombus-split</v-icon>
                 <v-chip
                   v-for="game in gathering.games"
@@ -79,7 +79,7 @@
               </div>
               <div
                 v-if="guestEntries(gathering).length"
-                class="event-line mb-2"
+                class="event-line mb-3"
               >
                 <v-icon size="16" class="mr-1">mdi-account-group</v-icon>
                 <v-chip
@@ -96,7 +96,7 @@
                   >{{ names[guest.uid] ?? '…' }}
                 </v-chip>
               </div>
-              <div v-else class="event-line mb-2">
+              <div v-else class="event-line mb-3">
                 <v-icon size="16" class="mr-1">mdi-account-group</v-icon>No
                 guests invited yet
               </div>
@@ -177,9 +177,9 @@
             <div
               v-for="gathering in invited"
               :key="gathering.id"
-              class="event-item pa-4 mb-3"
+              class="event-item pa-5 mb-4"
             >
-              <div class="d-flex align-center flex-wrap gap-2 mb-3">
+              <div class="d-flex align-center flex-wrap gap-3 mb-3">
                 <v-chip
                   :color="stateColor(gathering.state)"
                   size="small"
@@ -192,11 +192,11 @@
                   >{{ formatDatetime(gathering.datetime) }}</span
                 >
               </div>
-              <div class="event-line mb-2">
+              <div class="event-line mb-3">
                 <v-icon size="16" class="mr-1">mdi-account</v-icon>Hosted by
                 {{ names[gathering.host] ?? '…' }}
               </div>
-              <div v-if="gathering.games?.length" class="event-line mb-2">
+              <div v-if="gathering.games?.length" class="event-line mb-3">
                 <v-icon size="16" class="mr-1">mdi-rhombus-split</v-icon>
                 <v-chip
                   v-for="game in gathering.games"
@@ -526,11 +526,21 @@ function editGathering(gathering: GatheringWithId) {
     0 1px 4px rgba(200, 134, 10, 0.1);
 }
 .event-line {
-  font-size: 0.9rem;
+  font-size: 0.98rem;
+  line-height: 1.5;
   color: rgba(240, 223, 196, 0.85);
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 6px;
+}
+/* Slightly larger, more legible chips inside the event cards */
+.event-item :deep(.v-chip) {
+  font-size: 0.8rem !important;
+}
+/* A touch more room around the action buttons */
+.event-item .event-actions {
+  gap: 6px;
+  margin-top: 12px;
 }
 </style>

--- a/pages/friends.vue
+++ b/pages/friends.vue
@@ -28,7 +28,7 @@
         </v-card-text>
         <v-card-text v-else-if="friendsAreaOpen" class="pa-6">
           <template v-if="incomingRequests.length">
-            <div class="section-label mb-2">Friend Requests</div>
+            <div class="section-label mb-2">Friend requests</div>
             <v-list class="mb-4">
               <v-list-item
                 v-for="request in incomingRequests"
@@ -92,7 +92,7 @@
               class="mt-4"
               @click.stop="toggleAddArea"
             >
-              <v-icon start>mdi-plus-circle</v-icon>Find Friends
+              <v-icon start>mdi-plus-circle</v-icon>Find friends
             </v-btn>
           </div>
           <template v-else-if="friends.length">
@@ -191,7 +191,7 @@
                   color="primary"
                   variant="tonal"
                 >
-                  <v-icon start>mdi-clock-outline</v-icon>Request Sent
+                  <v-icon start>mdi-clock-outline</v-icon>Request sent
                 </v-chip>
                 <v-btn
                   v-else

--- a/pages/gamecollection.vue
+++ b/pages/gamecollection.vue
@@ -27,7 +27,7 @@
                 size="small"
                 @click.stop="activeArea = 'addGame'"
               >
-                <v-icon start>mdi-plus-circle</v-icon>Add Game
+                <v-icon start>mdi-plus-circle</v-icon>Add game
               </v-btn>
               <v-btn
                 variant="elevated"
@@ -83,13 +83,13 @@
                 class="mt-4"
                 @click.stop="activeArea = 'addGame'"
               >
-                <v-icon start>mdi-plus-circle</v-icon>Add Games
+                <v-icon start>mdi-plus-circle</v-icon>Add games
               </v-btn>
             </div>
             <div v-else>
               <v-text-field
                 v-model="filterGames"
-                label="Filter Games"
+                label="Filter games"
                 prepend-inner-icon="mdi-magnify"
                 clearable
                 class="mb-4"
@@ -186,7 +186,7 @@
                   >
                     <v-textarea
                       :model-value="opinions[item.id]?.privateNote ?? ''"
-                      label="Private Note"
+                      label="Private note"
                       variant="outlined"
                       density="compact"
                       rows="2"
@@ -204,10 +204,10 @@
               </v-list>
             </div>
 
-            <!-- Also Rated: games with opinions but not in collection (owner only) -->
+            <!-- Also rated: games with opinions but not in collection (owner only) -->
             <template v-if="!isFriendView && alsoRatedGames.length">
               <v-divider class="my-4" />
-              <div class="section-label mb-3">Also Rated</div>
+              <div class="section-label mb-3">Also rated</div>
               <v-list>
                 <template v-for="entry in alsoRatedGames" :key="entry.gameId">
                   <v-list-item class="game-item mb-2">
@@ -275,7 +275,7 @@
                   >
                     <v-textarea
                       :model-value="entry.privateNote ?? ''"
-                      label="Private Note"
+                      label="Private note"
                       variant="outlined"
                       density="compact"
                       rows="2"
@@ -312,7 +312,7 @@
               :loading="opinionSearchLoading"
               item-title="displayname"
               item-value="id"
-              label="Board Game Search"
+              label="Board game search"
               placeholder="Start typing to search"
               :hint="`Type at least ${constants.MinSearchLength} characters`"
               prepend-icon="mdi-database-search"
@@ -344,7 +344,7 @@
               />
               <v-textarea
                 v-model="pendingNote"
-                label="Private Note"
+                label="Private note"
                 variant="outlined"
                 density="compact"
                 rows="3"
@@ -409,7 +409,7 @@ import type {
 } from '~/helpers/types'
 import constants from '~/helpers/constants'
 
-useHead({ title: 'Game Collection' })
+useHead({ title: 'Game collection' })
 
 type ActiveArea = 'collection' | 'addGame' | 'addOpinion'
 
@@ -441,9 +441,9 @@ let unsubOpinions: (() => void) | null = null
 const pageTitle = computed(() => {
   if (isFriendView.value)
     return friendName.value ? `${friendName.value}'s Collection` : 'Collection'
-  if (activeArea.value === 'addGame') return 'Add Game'
+  if (activeArea.value === 'addGame') return 'Add game'
   if (activeArea.value === 'addOpinion') return 'Rate a Game'
-  return 'Game Collection'
+  return 'Game collection'
 })
 
 const gamesMatchingFilter = computed<Record<string, Game>>(() => {

--- a/pages/gatherings/new.vue
+++ b/pages/gatherings/new.vue
@@ -6,13 +6,17 @@
           <v-icon color="primary" class="mr-3">{{
             editId ? 'mdi-calendar-edit' : 'mdi-calendar-plus'
           }}</v-icon>
-          <h1 class="page-title">{{
-            editId ? 'Edit Gathering' : 'New Gathering'
-          }}</h1>
+          <h1 class="page-title">
+            {{ editId ? 'Edit gathering' : 'New gathering' }}
+          </h1>
         </v-card-title>
         <v-divider />
         <v-card-text v-if="loading" class="pa-8">
-          <v-progress-linear indeterminate color="primary" aria-label="Loading gathering" />
+          <v-progress-linear
+            indeterminate
+            color="primary"
+            aria-label="Loading gathering"
+          />
         </v-card-text>
         <v-card-text v-else class="pa-6">
           <v-form ref="gatheringForm" @submit.prevent="createGathering">
@@ -75,7 +79,7 @@
               :hint="
                 gameItems.length
                   ? ''
-                  : 'Add games on the Game Collection page to pick them'
+                  : 'Add games on the Game collection page to pick them'
               "
               persistent-hint
               class="mb-6"
@@ -88,7 +92,7 @@
               :loading="saving"
             >
               <v-icon start>mdi-calendar-check</v-icon
-              >{{ editId ? 'Save Changes' : 'Create Gathering' }}
+              >{{ editId ? 'Save changes' : 'Create gathering' }}
             </v-btn>
           </v-form>
         </v-card-text>
@@ -140,7 +144,7 @@ let existingGuests: Record<string, GuestResponse> = {}
 // initiator is pinned by the security rules: auth.uid at creation, immutable after
 let existingInitiator = ''
 
-useHead({ title: editId ? 'Edit Gathering' : 'New Gathering' })
+useHead({ title: editId ? 'Edit gathering' : 'New gathering' })
 
 const validation = {
   isRequired: (v: string) => !!v || 'Required',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -29,7 +29,7 @@
               class="hero-cta"
               elevation="8"
             >
-              Get Started
+              Get started
               <v-icon end>mdi-arrow-right</v-icon>
             </v-btn>
           </v-card-text>
@@ -71,17 +71,17 @@ useHead({ title: 'Welcome' })
 const features = [
   {
     icon: 'mdi-cards-outline',
-    title: 'Your Collection',
+    title: 'Your collection',
     desc: 'Catalog your board games with ratings and notes.',
   },
   {
     icon: 'mdi-account-group',
-    title: 'Find Friends',
+    title: 'Find friends',
     desc: 'Connect with fellow board game enthusiasts.',
   },
   {
     icon: 'mdi-dice-multiple',
-    title: 'Schedule Nights',
+    title: 'Schedule nights',
     desc: 'Plan gatherings around the games you love.',
   },
 ]
@@ -114,7 +114,7 @@ const features = [
 }
 
 .hero-title {
-  font-family: 'Cinzel', Georgia, serif;
+  font-family: 'Fraunces', Georgia, serif;
   font-size: 1.9rem;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -167,7 +167,7 @@ const features = [
 }
 
 .hero-cta {
-  font-family: 'Cinzel', Georgia, serif !important;
+  font-family: 'Fraunces', Georgia, serif !important;
   font-weight: 700 !important;
   letter-spacing: 0.1em !important;
   padding: 0 32px;

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -27,7 +27,11 @@
         </v-card-title>
         <v-divider />
         <v-card-text v-if="loading" class="pa-8">
-          <v-progress-linear indeterminate color="primary" aria-label="Loading profile" />
+          <v-progress-linear
+            indeterminate
+            color="primary"
+            aria-label="Loading profile"
+          />
         </v-card-text>
         <v-card-text v-else-if="editable" class="pa-6">
           <v-form ref="profileForm">
@@ -126,7 +130,7 @@ type UserProfile = {
 
 const labels = {
   name: 'Name',
-  phoneNumber: 'Phone Number',
+  phoneNumber: 'Phone number',
   email: 'Email',
   address: 'Address',
   maxPeople: 'Max people at residence',
@@ -284,11 +288,11 @@ async function updateProfile() {
   opacity: 0.9;
 }
 .profile-field-label {
-  font-family: 'Cinzel', Georgia, serif;
+  font-family: 'Fraunces', Georgia, serif;
   font-size: 0.8rem;
   color: #c8860a;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.1em;
   font-weight: 600;
   margin-bottom: 4px;
 }

--- a/pages/signin.vue
+++ b/pages/signin.vue
@@ -41,7 +41,7 @@ import { GoogleAuthProvider, FacebookAuthProvider } from 'firebase/auth'
 import Snackbar from '~/components/Snackbar.vue'
 import routes from '~/helpers/routes'
 
-useHead({ title: 'Sign In' })
+useHead({ title: 'Sign in' })
 
 const userStore = useUserStore()
 const router = useRouter()
@@ -69,7 +69,7 @@ const signInWithFacebook = () => handleOAuthSignIn(new FacebookAuthProvider())
 
 <style scoped>
 .signin-title {
-  font-family: 'Cinzel', Georgia, serif;
+  font-family: 'Fraunces', Georgia, serif;
   font-size: 1.75rem;
   font-weight: 700;
   letter-spacing: 0.04em;


### PR DESCRIPTION
## What

UI readability polish for the calendar and app-wide typography.

### Typography
- Replace **Cinzel** (a caps-only inscriptional display face that was illegible on small all-caps chips/buttons/labels) with **Fraunces** — a warm variable serif with a true optical-size axis, so small text uses the legible *text* cut and large titles the expressive *display* cut. Keeps the antique tabletop character while reading cleanly at every size.
- Move **chips** to **Lora** (the body serif) so small status tokens stay legible.
- Ease the heavy letter-spacing that only existed to space out Cinzel's caps.

### Calendar cards
- More breathing room: card padding `pa-4`→`pa-5`, bigger row gaps, larger line/chip sizes.
- Fix the state-chip / clock-icon gap (`gap-2`→`gap-3`).

### Copy
- Standardize all UI labels to **sentence case** (Material/Vuetify default), e.g. "Add Game"→"Add game", "Sign In"→"Sign in", "New Gathering"→"New gathering". Proper nouns preserved (brand, "Google Calendar", game/people names).

### Docs
- Document the typography and sentence-case copy conventions in `CLAUDE.md`.

## Testing
- `yarn lint` passes.
- Verified visually via `yarn screenshot` on `/calendar` (desktop + mobile) and the collection view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)