### PR TITLE
feat(collection): genre browse with virtualized list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Fixture data is in `scripts/fixtures/default.json` and mirrors the Firebase RTDB
 - `helpers/constants.ts` — `LoadingTimeoutInMs`, `DebounceThrottleInMs`, BGG API constants
 - `helpers/helpers.ts` — `handleError()`, HTML entity decoding for BGG API responses
 - `helpers/gatherings.ts` — `splitGatherings`, state/response color+icon maps, `formatDatetime`
+- `helpers/collection.ts` — `filterAndSortCollection` (text + genre filter, name/rating/recent sort → ordered `CollectionEntry[]`) and `collectionGenres`; pure + unit-tested (`test/collection.spec.ts`), drives the collection browse UI
 - `helpers/calendar.ts` — calendar-export builders: `googleCalendarUrl()` (Google "new event" template URL), `buildIcs()` (single-VEVENT `.ics`, `PUBLISH`, 3-hour default duration since gatherings store no end time, RFC-5545 escaped, no location since the host address is private), `downloadIcs()` (browser blob download), `toCalendarEventInput()`. The Cloud Functions duplicate this logic server-side (their build has its own `rootDir`, same as `formatDatetime`) — keep both in sync
 - `firebase.json` — Firebase Hosting config
 - `database.rules.json` — Firebase Realtime DB security rules (deployed by `cd.yml` on push to `main`, alongside functions)
@@ -131,6 +132,9 @@ type Game = {
   id: string // BoardGameGeek game ID
   name: string
   rating?: number
+  categories?: string[] // BGG `boardgamecategory` values (genres); used for the
+  // collection genre-filter chips. Stored as an RTDB array (numeric-keyed);
+  // rules validate each entry as a string ≤60 chars. Absent when BGG lists none.
 }
 
 // users/{uid}/friends/{friendId}: true — mutual; written to both sides on accept
@@ -180,7 +184,7 @@ BoardGameGeek XML API v2 — proxied via Firebase Cloud Functions (`bggSearch`, 
 
 - Search: `https://boardgamegeek.com/xmlapi2/search?query=<term>&type=boardgame`
 - Detail: `https://boardgamegeek.com/xmlapi2/thing?id=<id>`
-- XML is parsed server-side in the functions using `xml2js`; the client receives JSON
+- XML is parsed server-side in the functions using `xml2js`; the client receives JSON. `bggThing` also extracts `boardgamecategory` `<link>` values as `categories: string[]` (BGG's genre concept) via the `linkValues()` helper — these feed the collection genre-filter chips
 - **Authorization is required.** Every request must include an `Authorization: Bearer <token>` header. Tokens are created at https://boardgamegeek.com/applications after registering an application (non-commercial license is free). The token is stored in Secret Manager as `BGG_API_KEY` and accessed via `defineSecret('BGG_API_KEY')` in the Cloud Functions. Requests must go to `boardgamegeek.com` (no `www.` prefix) or the token will not work.
 - Subject to rate limits and occasional 202 "try again" responses
 - Client calls via `httpsCallable` from `firebase/functions`; App Check enforced
@@ -195,7 +199,7 @@ Transactional emails are sent server-side from `functions/src/index.ts` via Rese
 
 ## Test Setup
 
-Unit tests live in `test/` (`Logo.spec.ts`, `authErrors.spec.ts`, `gatherings.spec.ts`); security-rules tests in `test/rules/` run via `yarn test:rules` against the RTDB emulator (`vitest.rules.config.ts`). Vitest requires `environment: 'jsdom'` (set in `vitest.config.ts`). Vuetify must be inlined via `server.deps.inline: ['vuetify']` to avoid CSS import errors. Import `createVuetify` and pass it as a global plugin to `mount`.
+Unit tests live in `test/` (`Logo.spec.ts`, `authErrors.spec.ts`, `gatherings.spec.ts`, `collection.spec.ts`); security-rules tests in `test/rules/` run via `yarn test:rules` against the RTDB emulator (`vitest.rules.config.ts`). Vitest requires `environment: 'jsdom'` (set in `vitest.config.ts`). Vuetify must be inlined via `server.deps.inline: ['vuetify']` to avoid CSS import errors. Import `createVuetify` and pass it as a global plugin to `mount`.
 
 ## Design Conventions
 
@@ -265,7 +269,14 @@ All `v-card` elements are styled as walnut cardstock resting on the felt table:
 - Hover: border brightens to `rgba(200,134,10,0.4)`, shadow deepens
 - No `backdrop-filter`, no corner-bracket ornaments (both removed — they read as 90s-RTS HUD chrome)
 
-The table surface itself (felt + lamp glow + fabric grain) is painted on `body::before` / `body::after`; the walnut frame is the app bar and navigation drawer. Do not override card backgrounds inline — the global style handles it.
+The table surface itself (felt + lamp glow + fabric grain) is painted on `body::before` / `body::after`; the walnut frame is the app bar, navigation drawer, **and footer** — all three are opaque walnut so page content scrolls cleanly behind them (the footer must not be transparent, or long content shows through it). Do not override card backgrounds inline — the global style handles it.
+
+### Collection browse (genre filter)
+
+`gamecollection.vue` is the reference pattern for browsing a large list: a toolbar row (text filter + sort `v-select`), a `v-chip-group multiple` of genre facets (`filter` chips, `color="info"`; the group's `v-model` is the selected-genre `string[]` — use the group, not hand-rolled click + `aria-pressed`, so selection state and keyboard nav are correct), a "Showing N of M" count, then the list. Genres beyond `GENRE_CHIP_LIMIT` (12) collapse behind a "+N more" toggle. Genres come from BGG `categories`; each card shows up to 4 genre chips (`size="x-small"` `variant="tonal"` `color="info"`) with a `+N` overflow count. Sort options: name, my rating (own collection only — hidden in friend view), recently added (Firebase push-ID order, newest first).
+
+- **The list is virtualized** (`v-virtual-scroll`, `max-height="72vh"`) because collections can be large — never render the whole list with a plain `v-list`. The per-row note `v-textarea` is folded into the same row item (not a sibling list row) so the virtual scroller measures each row's height correctly when expanded. Do not add per-row entry animations (e.g. a `deal-in` stagger) to virtualized rows — they replay on every scroll recycle.
+- Filter/sort logic is a pure, unit-tested helper: `helpers/collection.ts` (`filterAndSortCollection`, `collectionGenres`). Keep it returning an **ordered array** (`CollectionEntry[] = { id, game }[]`); do not smuggle display order through an object's key-iteration order.
 
 ### Vuetify component defaults (set in `nuxt.config.ts`)
 

--- a/assets/global.scss
+++ b/assets/global.scss
@@ -317,12 +317,17 @@ body::after {
 }
 
 // ── Footer ────────────────────────────────────────────────────────────────────
+// Opaque walnut bottom rim of the frame — mirrors the app bar so page content
+// scrolls *behind* it cleanly instead of showing through a transparent strip.
 .v-footer.bgc-footer {
-  background: transparent !important;
-  border-top: 1px solid rgba(200, 134, 10, 0.1);
+  background: linear-gradient(0deg, #20140a 0%, #170e06 100%) !important;
+  border-top: 1px solid rgba(200, 134, 10, 0.2);
+  box-shadow:
+    inset 0 1px 0 rgba(240, 223, 196, 0.05),
+    0 -2px 16px rgba(0, 0, 0, 0.55);
   font-size: 0.75rem;
   font-family: 'Lora', Georgia, serif;
-  color: rgba(240, 223, 196, 0.60);
+  color: rgba(240, 223, 196, 0.6);
   justify-content: center;
 }
 

--- a/composables/useBoardGameSearch.ts
+++ b/composables/useBoardGameSearch.ts
@@ -3,7 +3,10 @@ import type { Ref } from 'vue'
 import { httpsCallable } from 'firebase/functions'
 import { useNuxtApp } from 'nuxt/app'
 import helpers from '~/helpers/helpers'
-import type { BoardGameSearchResult, DisplayableItemType } from '~/helpers/types'
+import type {
+  BoardGameSearchResult,
+  DisplayableItemType,
+} from '~/helpers/types'
 import constants from '~/helpers/constants'
 
 interface BggSearchResult {
@@ -25,6 +28,7 @@ interface BggThingResult {
   minplaytime: string | null
   maxplaytime: string | null
   minage: string | null
+  categories: string[] | null
 }
 
 // Score a result by how closely its name matches the search query.
@@ -32,11 +36,11 @@ interface BggThingResult {
 function relevanceScore(name: string, query: string): number {
   const n = name.toLowerCase()
   const q = query.toLowerCase()
-  if (n === q) return 0               // exact match
-  if (n.startsWith(q + ' ') || n.startsWith(q + ':')) return 1  // query is the full first word
-  if (n.startsWith(q)) return 2       // prefix match
-  if (n.includes(q)) return 3         // substring match
-  return 4                            // BGG matched it some other way (alternate name, etc.)
+  if (n === q) return 0 // exact match
+  if (n.startsWith(q + ' ') || n.startsWith(q + ':')) return 1 // query is the full first word
+  if (n.startsWith(q)) return 2 // prefix match
+  if (n.includes(q)) return 3 // substring match
+  return 4 // BGG matched it some other way (alternate name, etc.)
 }
 
 export function useBoardGameSearch(
@@ -74,10 +78,10 @@ export function useBoardGameSearch(
   async function displayEntries() {
     try {
       const entries = _getEntriesToShow()
-      const bggThingFn = httpsCallable<{ ids: string[] }, { items: BggThingResult[] }>(
-        $functions,
-        'bggThing'
-      )
+      const bggThingFn = httpsCallable<
+        { ids: string[] },
+        { items: BggThingResult[] }
+      >($functions, 'bggThing')
       const result = await bggThingFn({ ids: entries.map((e) => e.id) })
       queriedEntries.value = (result.data.items ?? [])
         .filter((item): item is BggThingResult => !!item)
@@ -97,6 +101,7 @@ export function useBoardGameSearch(
             minplayers: item.minplayers ?? '',
             minplaytime: item.minplaytime ?? '',
             yearpublished: item.yearpublished ?? '',
+            categories: item.categories ?? [],
             incollection: false,
           }
         })
@@ -106,7 +111,8 @@ export function useBoardGameSearch(
   }
 
   async function fetchResults(input: string) {
-    if (isLoading.value || !input || input.length < constants.MinSearchLength) return
+    if (isLoading.value || !input || input.length < constants.MinSearchLength)
+      return
     isLoading.value = true
     try {
       const bggSearchFn = httpsCallable<
@@ -129,7 +135,8 @@ export function useBoardGameSearch(
           yearpublished: item.yearpublished ?? '0',
         }))
         .sort((a, b) => {
-          const scoreDiff = relevanceScore(a.name, query) - relevanceScore(b.name, query)
+          const scoreDiff =
+            relevanceScore(a.name, query) - relevanceScore(b.name, query)
           if (scoreDiff !== 0) return scoreDiff
           // Within the same relevance tier: shorter name first (less noise),
           // then more recent year as tiebreaker

--- a/database.rules.json
+++ b/database.rules.json
@@ -62,6 +62,11 @@
             "yearpublished": {
               ".validate": "newData.isString() && newData.val().length <= 10"
             },
+            "categories": {
+              "$index": {
+                ".validate": "newData.isString() && newData.val().length <= 60"
+              }
+            },
             "publicNote": {
               ".validate": "newData.isString() && newData.val().length <= 2000"
             },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -75,6 +75,19 @@ function itemAttr(item: unknown, prop: string): string | null {
   return typeof v === 'string' ? v : null
 }
 
+// BGG `thing` items carry repeated <link type="..." value="..."> elements
+// (categories, mechanics, families). Collect the values of a given link type.
+// `boardgamecategory` is BGG's genre concept (Economic, Fantasy, Card Game…).
+function linkValues(itemObj: Record<string, unknown>, type: string): string[] {
+  const node = itemObj.link
+  if (node == null) return []
+  const arr: unknown[] = Array.isArray(node) ? node : [node]
+  return arr
+    .filter((l) => itemAttr(l, 'type') === type)
+    .map((l) => itemAttr(l, 'value'))
+    .filter((v): v is string => typeof v === 'string' && v.length > 0)
+}
+
 export const bggSearch = onCall(
   { enforceAppCheck: true, secrets: [BGG_API_KEY] },
   async (request) => {
@@ -184,6 +197,7 @@ function parseBggThingItem(item: unknown) {
     minplaytime: attrValue(itemObj.minplaytime),
     maxplaytime: attrValue(itemObj.maxplaytime),
     minage: attrValue(itemObj.minage),
+    categories: linkValues(itemObj, 'boardgamecategory'),
   }
 }
 

--- a/helpers/collection.ts
+++ b/helpers/collection.ts
@@ -1,0 +1,62 @@
+import type { Game } from '~/helpers/types'
+
+export type CollectionSort = 'name' | 'rating' | 'recent'
+
+// A collection entry paired with its Firebase push-ID key. The list renders
+// these directly — an honest ordered array, not an order smuggled through an
+// object's key iteration.
+export interface CollectionEntry {
+  id: string
+  game: Game
+}
+
+export interface FilterSortOptions {
+  text: string
+  genres: Set<string>
+  sortBy: CollectionSort
+  // Resolves a game's rating (0 when unrated). Ratings live in gameOpinions,
+  // keyed by BGG game id, so the caller injects the lookup.
+  ratingFor: (gameId: string) => number
+}
+
+// Distinct genres present across the collection, alphabetized.
+export function collectionGenres(
+  collection: Record<string, Game> | null
+): string[] {
+  if (!collection) return []
+  const set = new Set<string>()
+  for (const game of Object.values(collection))
+    game.categories?.forEach((c) => set.add(c))
+  return [...set].sort((a, b) => a.localeCompare(b))
+}
+
+// Filter by name substring + selected genres, then sort. Returns a new array;
+// does not mutate the input.
+export function filterAndSortCollection(
+  collection: Record<string, Game> | null,
+  { text, genres, sortBy, ratingFor }: FilterSortOptions
+): CollectionEntry[] {
+  if (!collection) return []
+  const needle = text.toLowerCase()
+
+  const entries: CollectionEntry[] = Object.entries(collection)
+    .filter(([, game]) => {
+      if (!game.name.toLowerCase().includes(needle)) return false
+      if (genres.size === 0) return true
+      return game.categories?.some((c) => genres.has(c)) ?? false
+    })
+    .map(([id, game]) => ({ id, game }))
+
+  entries.sort((a, b) => {
+    if (sortBy === 'name') return a.game.name.localeCompare(b.game.name)
+    if (sortBy === 'rating') {
+      const diff = ratingFor(b.game.id) - ratingFor(a.game.id)
+      return diff !== 0 ? diff : a.game.name.localeCompare(b.game.name)
+    }
+    // 'recent': Firebase push IDs sort lexicographically by creation time;
+    // newest first.
+    return a.id < b.id ? 1 : a.id > b.id ? -1 : 0
+  })
+
+  return entries
+}

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -26,12 +26,13 @@ export type Friend = Person & {
 export type Game = {
   id: string
   name: string
-  thumbnail: string   // always present in BGG
+  thumbnail: string // always present in BGG
   minplayers?: string // nullable in BGG
   maxplayers?: string // nullable in BGG
   minplaytime?: string // nullable in BGG
   maxplaytime?: string // nullable in BGG
   yearpublished?: string // nullable in BGG
+  categories?: string[] // BGG boardgamecategory values (genres); absent if none
   publicNote?: string
 }
 
@@ -79,6 +80,7 @@ export type DisplayableItemType = {
   minplayers: string
   minplaytime: string
   yearpublished: string
+  categories: string[]
   incollection: boolean
 }
 

--- a/pages/gamecollection.vue
+++ b/pages/gamecollection.vue
@@ -87,15 +87,73 @@
               </v-btn>
             </div>
             <div v-else>
-              <v-text-field
-                v-model="filterGames"
-                label="Filter games"
-                prepend-inner-icon="mdi-magnify"
-                clearable
-                class="mb-4"
-              />
-              <v-list>
-                <template v-for="(item, id) in gamesMatchingFilter" :key="id">
+              <div class="d-flex gap-3 mb-3 flex-wrap align-center">
+                <v-text-field
+                  v-model="filterGames"
+                  label="Filter games"
+                  prepend-inner-icon="mdi-magnify"
+                  clearable
+                  hide-details
+                  class="flex-grow-1"
+                  style="min-width: 180px"
+                />
+                <v-select
+                  v-model="sortBy"
+                  :items="sortOptions"
+                  label="Sort"
+                  hide-details
+                  style="max-width: 190px"
+                />
+              </div>
+
+              <div v-if="availableGenres.length" class="mb-3">
+                <v-chip-group
+                  v-model="selectedGenres"
+                  multiple
+                  column
+                  selected-class="text-primary"
+                >
+                  <v-chip
+                    v-for="genre in visibleGenres"
+                    :key="genre"
+                    :value="genre"
+                    size="small"
+                    filter
+                    variant="outlined"
+                    color="info"
+                  >
+                    {{ genre }}
+                  </v-chip>
+                </v-chip-group>
+                <v-btn
+                  v-if="availableGenres.length > GENRE_CHIP_LIMIT"
+                  variant="text"
+                  size="small"
+                  color="accent"
+                  @click="showAllGenres = !showAllGenres"
+                >
+                  {{
+                    showAllGenres
+                      ? 'Show fewer'
+                      : `+${availableGenres.length - GENRE_CHIP_LIMIT} more`
+                  }}
+                </v-btn>
+              </div>
+
+              <div class="text-caption text-medium-emphasis mb-3">
+                Showing {{ visibleGames.length }} of {{ totalGames }}
+              </div>
+
+              <div v-if="!visibleGames.length" class="empty-desc py-4">
+                No games match your filters.
+              </div>
+              <v-virtual-scroll
+                v-else
+                :items="visibleGames"
+                item-height="104"
+                max-height="72vh"
+              >
+                <template #default="{ item: entry }">
                   <v-list-item class="game-item mb-2">
                     <template #prepend>
                       <v-avatar
@@ -105,30 +163,50 @@
                         class="mr-3"
                       >
                         <v-img
-                          v-if="item.thumbnail"
-                          :src="item.thumbnail"
-                          :alt="item.name"
+                          v-if="entry.game.thumbnail"
+                          :src="entry.game.thumbnail"
+                          :alt="entry.game.name"
                         />
                         <v-icon v-else size="32"
                           >mdi-gamepad-variant-outline</v-icon
                         >
                       </v-avatar>
                     </template>
-                    <v-list-item-title>{{ item.name }}</v-list-item-title>
+                    <v-list-item-title>{{ entry.game.name }}</v-list-item-title>
+                    <div
+                      v-if="entry.game.categories?.length"
+                      class="d-flex flex-wrap align-center gap-1 mt-1 mb-1"
+                    >
+                      <v-chip
+                        v-for="cat in entry.game.categories.slice(0, 4)"
+                        :key="cat"
+                        size="x-small"
+                        variant="tonal"
+                        color="info"
+                        >{{ cat }}</v-chip
+                      >
+                      <span
+                        v-if="entry.game.categories.length > 4"
+                        class="text-caption text-medium-emphasis"
+                        >+{{ entry.game.categories.length - 4 }}</span
+                      >
+                    </div>
                     <v-rating
                       v-if="!isFriendView"
-                      :model-value="opinions[item.id]?.rating ?? 0"
+                      :model-value="opinions[entry.game.id]?.rating ?? 0"
                       hover
                       size="small"
                       color="warning"
                       active-color="warning"
-                      @update:model-value="(val) => updateGameRating(item, val)"
+                      @update:model-value="
+                        (val) => updateGameRating(entry.game, val)
+                      "
                     />
                     <div
-                      v-if="formatGameInfo(item)"
+                      v-if="formatGameInfo(entry.game)"
                       class="text-caption text-medium-emphasis"
                     >
-                      {{ formatGameInfo(item) }}
+                      {{ formatGameInfo(entry.game) }}
                     </div>
                     <div class="event-actions">
                       <v-btn
@@ -136,7 +214,7 @@
                         size="small"
                         variant="tonal"
                         color="accent"
-                        :href="`https://boardgamegeek.com/boardgame/${item.id}`"
+                        :href="`https://boardgamegeek.com/boardgame/${entry.game.id}`"
                         target="_blank"
                         rel="noopener noreferrer"
                         aria-label="Open on BGG"
@@ -150,19 +228,19 @@
                         size="small"
                         variant="tonal"
                         :color="
-                          expandedItems.has(String(id)) ? 'primary' : 'accent'
+                          expandedItems.has(entry.id) ? 'primary' : 'accent'
                         "
                         :aria-label="
-                          expandedItems.has(String(id))
+                          expandedItems.has(entry.id)
                             ? 'Hide note'
                             : 'Edit note'
                         "
                         :title="
-                          expandedItems.has(String(id))
+                          expandedItems.has(entry.id)
                             ? 'Hide note'
                             : 'Edit note'
                         "
-                        @click.stop="toggleExpanded(String(id))"
+                        @click.stop="toggleExpanded(entry.id)"
                       >
                         <v-icon>mdi-note-text-outline</v-icon>
                       </v-btn>
@@ -174,34 +252,31 @@
                         color="error"
                         aria-label="Remove from collection"
                         title="Remove from collection"
-                        @click.stop="removeGameFromCollection(String(id))"
+                        @click.stop="removeGameFromCollection(entry.id)"
                       >
                         <v-icon>mdi-delete-outline</v-icon>
                       </v-btn>
                     </div>
-                  </v-list-item>
-                  <v-list-item
-                    v-if="!isFriendView && expandedItems.has(String(id))"
-                    class="px-4 pb-2"
-                  >
                     <v-textarea
-                      :model-value="opinions[item.id]?.privateNote ?? ''"
+                      v-if="!isFriendView && expandedItems.has(entry.id)"
+                      :model-value="opinions[entry.game.id]?.privateNote ?? ''"
                       label="Private note"
                       variant="outlined"
                       density="compact"
                       rows="2"
                       hide-details
+                      class="mt-2"
                       @blur="
                         (e: FocusEvent) =>
                           updateGameNote(
-                            item,
+                            entry.game,
                             (e.target as HTMLTextAreaElement).value
                           )
                       "
                     />
                   </v-list-item>
                 </template>
-              </v-list>
+              </v-virtual-scroll>
             </div>
 
             <!-- Also rated: games with opinions but not in collection (owner only) -->
@@ -408,6 +483,11 @@ import type {
   BoardGameSearchResult,
 } from '~/helpers/types'
 import constants from '~/helpers/constants'
+import {
+  collectionGenres,
+  filterAndSortCollection,
+  type CollectionSort,
+} from '~/helpers/collection'
 
 useHead({ title: 'Game collection' })
 
@@ -432,6 +512,16 @@ const collection = ref<Record<string, Game> | null>(null)
 const opinions = ref<Record<string, GameOpinion>>({})
 const loading = ref(true)
 const filterGames = ref<string | null>('')
+const selectedGenres = ref<string[]>([])
+const sortBy = ref<CollectionSort>('name')
+const showAllGenres = ref(false)
+// "My rating" sort only makes sense for your own collection.
+const sortOptions = computed(() => [
+  { title: 'Name', value: 'name' },
+  ...(isFriendView.value ? [] : [{ title: 'My rating', value: 'rating' }]),
+  { title: 'Recently added', value: 'recent' },
+])
+const GENRE_CHIP_LIMIT = 12
 const activeArea = ref<ActiveArea>('collection')
 const expandedItems = ref(new Set<string>())
 
@@ -446,15 +536,28 @@ const pageTitle = computed(() => {
   return 'Game collection'
 })
 
-const gamesMatchingFilter = computed<Record<string, Game>>(() => {
-  if (!collection.value) return {}
-  const filter = (filterGames.value ?? '').toLowerCase()
-  const result: Record<string, Game> = {}
-  for (const [key, game] of Object.entries(collection.value)) {
-    if (game.name.toLowerCase().includes(filter)) result[key] = game
-  }
-  return result
-})
+// Distinct genres present in the collection, alphabetized — drives the chips.
+const availableGenres = computed(() => collectionGenres(collection.value))
+const visibleGenres = computed(() =>
+  showAllGenres.value
+    ? availableGenres.value
+    : availableGenres.value.slice(0, GENRE_CHIP_LIMIT)
+)
+
+const totalGames = computed(() =>
+  collection.value ? Object.keys(collection.value).length : 0
+)
+
+// Text filter + genre facets + sort, as an honest ordered array. Logic lives in
+// helpers/collection.ts (unit-tested); this just wires in the reactive inputs.
+const visibleGames = computed(() =>
+  filterAndSortCollection(collection.value, {
+    text: filterGames.value ?? '',
+    genres: new Set(selectedGenres.value),
+    sortBy: sortBy.value,
+    ratingFor: (id) => opinions.value[id]?.rating ?? 0,
+  })
+)
 
 const idsInCollection = computed(() =>
   collection.value ? Object.values(collection.value).map((g) => g.id) : []
@@ -591,6 +694,7 @@ type BggGameMeta = {
   minplaytime?: string | null
   maxplaytime?: string | null
   yearpublished?: string | null
+  categories?: string[] | null
 }
 
 function formatGameInfo(game: Game): string {
@@ -631,6 +735,7 @@ function buildGame(id: string, data: BggGameMeta, fallbackName: string): Game {
   if (data.maxplaytime) game.maxplaytime = data.maxplaytime
   if (data.yearpublished && data.yearpublished !== '0')
     game.yearpublished = data.yearpublished
+  if (data.categories?.length) game.categories = data.categories
   return game
 }
 
@@ -826,37 +931,14 @@ function onGameSearchError(error: Error) {
 </script>
 
 <style scoped>
+/* No deal-in stagger here: rows are virtualized and recycled on scroll, so a
+   per-row entry animation would replay continuously as you scroll. */
 .game-item {
   border-radius: 6px;
   transition:
     background 0.2s ease,
     transform 0.2s ease,
     box-shadow 0.2s ease;
-  animation: deal-in 0.3s ease both;
-}
-.game-item:nth-child(1) {
-  animation-delay: 0ms;
-}
-.game-item:nth-child(2) {
-  animation-delay: 40ms;
-}
-.game-item:nth-child(3) {
-  animation-delay: 80ms;
-}
-.game-item:nth-child(4) {
-  animation-delay: 120ms;
-}
-.game-item:nth-child(5) {
-  animation-delay: 160ms;
-}
-.game-item:nth-child(6) {
-  animation-delay: 200ms;
-}
-.game-item:nth-child(7) {
-  animation-delay: 240ms;
-}
-.game-item:nth-child(8) {
-  animation-delay: 280ms;
 }
 .game-item:hover {
   background: rgba(200, 134, 10, 0.07);

--- a/test/collection.spec.ts
+++ b/test/collection.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { collectionGenres, filterAndSortCollection } from '~/helpers/collection'
+import type { Game } from '~/helpers/types'
+
+function game(overrides: Partial<Game> & { id: string; name: string }): Game {
+  return { thumbnail: '', ...overrides }
+}
+
+// Push IDs sort lexicographically by creation time. g1 oldest, g3 newest.
+const collection: Record<string, Game> = {
+  '-g1': game({ id: '1', name: 'Azul', categories: ['Abstract', 'Strategy'] }),
+  '-g2': game({ id: '2', name: 'Brass', categories: ['Economic'] }),
+  '-g3': game({ id: '3', name: 'Catan', categories: ['Economic', 'Strategy'] }),
+  '-g4': game({ id: '4', name: 'Dune' }), // no categories
+}
+
+const ratings: Record<string, number> = { '1': 5, '2': 3, '3': 4 }
+const ratingFor = (id: string) => ratings[id] ?? 0
+
+describe('collectionGenres', () => {
+  it('returns distinct genres alphabetized', () => {
+    expect(collectionGenres(collection)).toEqual([
+      'Abstract',
+      'Economic',
+      'Strategy',
+    ])
+  })
+
+  it('handles a null collection', () => {
+    expect(collectionGenres(null)).toEqual([])
+  })
+})
+
+describe('filterAndSortCollection', () => {
+  const base = {
+    text: '',
+    genres: new Set<string>(),
+    sortBy: 'name' as const,
+    ratingFor,
+  }
+
+  it('sorts by name', () => {
+    const names = filterAndSortCollection(collection, base).map(
+      (e) => e.game.name
+    )
+    expect(names).toEqual(['Azul', 'Brass', 'Catan', 'Dune'])
+  })
+
+  it('sorts by rating descending, name as tiebreak, unrated last', () => {
+    const names = filterAndSortCollection(collection, {
+      ...base,
+      sortBy: 'rating',
+    }).map((e) => e.game.name)
+    expect(names).toEqual(['Azul', 'Catan', 'Brass', 'Dune'])
+  })
+
+  it('sorts by recency (newest push id first)', () => {
+    const ids = filterAndSortCollection(collection, {
+      ...base,
+      sortBy: 'recent',
+    }).map((e) => e.id)
+    expect(ids).toEqual(['-g4', '-g3', '-g2', '-g1'])
+  })
+
+  it('filters by case-insensitive name substring', () => {
+    const names = filterAndSortCollection(collection, {
+      ...base,
+      text: 'a',
+    }).map((e) => e.game.name)
+    expect(names).toEqual(['Azul', 'Brass', 'Catan'])
+  })
+
+  it('filters by genre (union across selected genres)', () => {
+    const names = filterAndSortCollection(collection, {
+      ...base,
+      genres: new Set(['Economic']),
+    }).map((e) => e.game.name)
+    expect(names).toEqual(['Brass', 'Catan'])
+  })
+
+  it('combines text and genre filters', () => {
+    const names = filterAndSortCollection(collection, {
+      ...base,
+      text: 'c',
+      genres: new Set(['Strategy']),
+    }).map((e) => e.game.name)
+    expect(names).toEqual(['Catan'])
+  })
+
+  it('excludes uncategorized games when a genre is selected', () => {
+    const names = filterAndSortCollection(collection, {
+      ...base,
+      genres: new Set(['Strategy']),
+    }).map((e) => e.game.name)
+    expect(names).not.toContain('Dune')
+  })
+
+  it('returns an empty array for a null collection', () => {
+    expect(filterAndSortCollection(null, base)).toEqual([])
+  })
+})

--- a/test/rules/database.rules.spec.ts
+++ b/test/rules/database.rules.spec.ts
@@ -21,7 +21,10 @@ import {
 
 let testEnv: RulesTestEnvironment
 
-const db = (uid?: string, claims?: { email?: string; email_verified?: boolean }) =>
+const db = (
+  uid?: string,
+  claims?: { email?: string; email_verified?: boolean }
+) =>
   uid
     ? testEnv.authenticatedContext(uid, claims).database()
     : testEnv.unauthenticatedContext().database()
@@ -95,7 +98,9 @@ describe('public profile (profiles/) rules', () => {
   })
 
   it('only lets a user write their own public profile', async () => {
-    await assertSucceeds(set(ref(alice(), 'profiles/alice'), alicePublicProfile))
+    await assertSucceeds(
+      set(ref(alice(), 'profiles/alice'), alicePublicProfile)
+    )
     await assertFails(set(ref(db('bob'), 'profiles/alice'), alicePublicProfile))
   })
 
@@ -132,7 +137,9 @@ describe('public profile (profiles/) rules', () => {
   })
 
   it('binds queryableEmail to the verified auth token email', async () => {
-    await assertSucceeds(set(ref(alice(), 'profiles/alice'), alicePublicProfile))
+    await assertSucceeds(
+      set(ref(alice(), 'profiles/alice'), alicePublicProfile)
+    )
     // bob claiming alice's email to show up in her search results
     await assertFails(
       set(
@@ -242,7 +249,9 @@ describe('private profile (users/) rules', () => {
   })
 
   it('only lets a user write their own private profile', async () => {
-    await assertSucceeds(set(ref(db('alice'), 'users/alice'), alicePrivateProfile))
+    await assertSucceeds(
+      set(ref(db('alice'), 'users/alice'), alicePrivateProfile)
+    )
     await assertFails(set(ref(db('bob'), 'users/alice'), alicePrivateProfile))
   })
 
@@ -298,6 +307,30 @@ describe('private profile (users/) rules', () => {
         id: '13',
         name: 'Catan',
         junk: 'x',
+      })
+    )
+  })
+
+  it('accepts a categories array of short strings, rejects oversized/non-string', async () => {
+    await assertSucceeds(
+      set(ref(db('alice'), 'users/alice/collection/g1'), {
+        id: '13',
+        name: 'Catan',
+        categories: ['Economic', 'Negotiation'],
+      })
+    )
+    await assertFails(
+      set(ref(db('alice'), 'users/alice/collection/g2'), {
+        id: '14',
+        name: 'Brass',
+        categories: ['x'.repeat(61)],
+      })
+    )
+    await assertFails(
+      set(ref(db('alice'), 'users/alice/collection/g3'), {
+        id: '15',
+        name: 'Azul',
+        categories: [42],
       })
     )
   })
@@ -389,7 +422,9 @@ describe('friend request rules', () => {
       set(ref(db('mallory'), 'friendRequests/mallory/bob'), 'pending')
     )
     // and without a real request from bob, she cannot add herself to his list
-    await assertFails(set(ref(db('mallory'), 'users/bob/friends/mallory'), true))
+    await assertFails(
+      set(ref(db('mallory'), 'users/bob/friends/mallory'), true)
+    )
   })
 
   it('keeps friends lists private to their owner', async () => {
@@ -438,7 +473,6 @@ describe('blocked list rules', () => {
     await assertFails(get(ref(db('bob'), 'blocked/alice/bob')))
   })
 })
-
 
 // the invite gate: a host may only invite users whose own friends list
 // contains the host (i.e. mutual friendship, which the host cannot forge)
@@ -630,12 +664,16 @@ describe('userGatherings index rules', () => {
 
   it('blocks indexing users who are not participants of the gathering', async () => {
     await seed('gatherings/g1', baseGathering)
-    await assertFails(set(ref(db('host1'), 'userGatherings/stranger1/g1'), true))
+    await assertFails(
+      set(ref(db('host1'), 'userGatherings/stranger1/g1'), true)
+    )
   })
 
   it('blocks non-hosts from writing index entries', async () => {
     await seed('gatherings/g1', baseGathering)
-    await assertFails(set(ref(db('mallory'), 'userGatherings/mallory/g1'), true))
+    await assertFails(
+      set(ref(db('mallory'), 'userGatherings/mallory/g1'), true)
+    )
     await assertFails(set(ref(db('guest1'), 'userGatherings/guest1/g1'), true))
   })
 
@@ -651,7 +689,9 @@ describe('userGatherings index rules', () => {
   it('lets a user always remove their own entry (dangling-pointer cleanup)', async () => {
     await seed('userGatherings/guest1/ghost', true)
     await assertFails(remove(ref(db('mallory'), 'userGatherings/guest1/ghost')))
-    await assertSucceeds(remove(ref(db('guest1'), 'userGatherings/guest1/ghost')))
+    await assertSucceeds(
+      remove(ref(db('guest1'), 'userGatherings/guest1/ghost'))
+    )
   })
 
   it('lets the host remove a guest entry while uninviting', async () => {


### PR DESCRIPTION
Makes large game collections browsable instead of just scrollable, and fixes the footer overlapping page content.

## What

- **Genre data from BGG.** `bggThing` now parses `boardgamecategory` `<link>` values (BGG's genre concept) into `Game.categories`; validated as a string array in the RTDB rules.
- **Browse UI** (`gamecollection.vue`): multi-select genre `v-chip-group`, sort (name / my rating / recently added), live "Showing N of M" count, per-card genre chips with `+N` overflow, and a "+N more" toggle when genres exceed the chip limit. "My rating" sort is hidden in the friend view.
- **Virtualized list** (`v-virtual-scroll`): collection size no longer drives DOM node and thumbnail-request count — the original "collections can be large" problem. The per-row note textarea is folded into the row so the scroller measures expanded heights; the `deal-in` stagger is dropped (it replayed on every scroll recycle).
- **Pure, tested core.** Filter/sort logic lives in `helpers/collection.ts` and returns an ordered `CollectionEntry[]` (no display order smuggled through object key iteration). Covered by `test/collection.spec.ts`.
- **Footer fix.** The footer was `transparent`, so page content scrolled visibly behind the copyright. It's now an opaque walnut surface, consistent with the app bar / nav drawer frame.

## Testing

- `yarn lint` — pass
- `yarn test` — pass (25 tests; 10 new in `test/collection.spec.ts`)
- `yarn workspace functions build` — pass
- `yarn test:rules` — **not run locally** (requires JDK 21; the new `categories` assertions follow the existing `$index`/string-length pattern)
- Not yet eyeballed in a running browser — `v-virtual-scroll` with the folded-in expanding textarea is worth a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)