### PR TITLE
fix(mobile): fix cramped game card layout in add-game search flow

### DIFF
--- a/components/GameSearch.vue
+++ b/components/GameSearch.vue
@@ -18,48 +18,47 @@
       @click="resetData"
     />
     <v-list>
-      <v-list-item v-for="(item, i) in entriesToShow" :key="i">
+      <v-list-item v-for="(item, i) in entriesToShow" :key="i" class="search-result-item mb-2">
         <template #prepend>
-          <v-avatar rounded="0" size="56" color="surface-variant">
+          <v-avatar rounded="0" size="48" color="surface-variant" class="mr-3 flex-shrink-0">
             <v-img
               v-if="item.thumbnail"
               :src="item.thumbnail"
               :alt="item.name"
             />
-            <v-icon v-else size="32">mdi-gamepad-variant-outline</v-icon>
+            <v-icon v-else size="28">mdi-gamepad-variant-outline</v-icon>
           </v-avatar>
         </template>
 
         <v-list-item-title>
           {{ item.name }} ({{ item.yearpublished }})
         </v-list-item-title>
-        <v-list-item-subtitle>{{ item.description }}</v-list-item-subtitle>
-
-        <template #append>
-          <div class="d-flex">
-            <v-btn
-              :disabled="item.incollection"
-              color="primary"
-              size="small"
-              class="mr-2"
-              @click.stop="addToCollection(item)"
-            >
-              <v-icon start>mdi-plus-circle</v-icon>Add
-            </v-btn>
-            <v-btn
-              :href="item.url"
-              target="_blank"
-              rel="noopener noreferrer"
-              color="primary"
-              size="small"
-            >
-              <v-icon start>mdi-link</v-icon>Link
-            </v-btn>
-          </div>
-        </template>
+        <v-list-item-subtitle v-if="item.description">{{ item.description }}</v-list-item-subtitle>
+        <div class="event-actions mt-1">
+          <v-btn
+            :disabled="item.incollection"
+            color="primary"
+            size="small"
+            @click.stop="addToCollection(item)"
+          >
+            <v-icon start>mdi-plus-circle</v-icon>Add
+          </v-btn>
+          <v-btn
+            :href="item.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            color="accent"
+            size="small"
+            variant="text"
+            aria-label="View on BGG"
+            title="View on BGG"
+          >
+            <v-icon start>mdi-open-in-new</v-icon>BGG
+          </v-btn>
+        </div>
       </v-list-item>
     </v-list>
-    <div v-if="!selectedItem && entriesToShow.length !== searchResults.length">
+    <div v-if="!selectedItem && entriesToShow.length !== searchResults.length" class="text-caption text-medium-emphasis mt-1">
       Showing the top {{ constants.NumberToShow }} matches — refine your search
       to narrow the results.
     </div>
@@ -104,3 +103,21 @@ watch(selectedItem, () => {
   displayEntries()
 })
 </script>
+
+<style scoped>
+.search-result-item {
+  border-radius: 6px;
+  transition: background 0.2s ease;
+}
+.search-result-item:hover {
+  background: rgba(200, 134, 10, 0.07);
+}
+.search-result-item :deep(.v-list-item-title) {
+  white-space: normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.35;
+}
+</style>

--- a/components/GameSearch.vue
+++ b/components/GameSearch.vue
@@ -20,7 +20,7 @@
     <v-list>
       <v-list-item v-for="(item, i) in entriesToShow" :key="i" class="search-result-item mb-2">
         <template #prepend>
-          <v-avatar rounded="0" size="56" color="surface-variant" class="mr-3 flex-shrink-0">
+          <v-avatar rounded="0" size="56" color="surface-variant" class="mr-3">
             <v-img
               v-if="item.thumbnail"
               :src="item.thumbnail"
@@ -36,24 +36,29 @@
         <v-list-item-subtitle v-if="item.description">{{ item.description }}</v-list-item-subtitle>
         <div class="event-actions mt-1">
           <v-btn
+            icon
             :disabled="item.incollection"
-            color="primary"
             size="small"
+            variant="tonal"
+            color="primary"
+            :aria-label="item.incollection ? 'Already in collection' : 'Add to collection'"
+            :title="item.incollection ? 'Already in collection' : 'Add to collection'"
             @click.stop="addToCollection(item)"
           >
-            <v-icon start>mdi-plus-circle</v-icon>Add
+            <v-icon>mdi-plus-circle</v-icon>
           </v-btn>
           <v-btn
+            icon
             :href="item.url"
             target="_blank"
             rel="noopener noreferrer"
-            color="accent"
             size="small"
-            variant="text"
+            variant="tonal"
+            color="accent"
             aria-label="View on BGG"
             title="View on BGG"
           >
-            <v-icon start>mdi-open-in-new</v-icon>BGG
+            <v-icon>mdi-open-in-new</v-icon>
           </v-btn>
         </div>
       </v-list-item>

--- a/components/GameSearch.vue
+++ b/components/GameSearch.vue
@@ -20,13 +20,13 @@
     <v-list>
       <v-list-item v-for="(item, i) in entriesToShow" :key="i" class="search-result-item mb-2">
         <template #prepend>
-          <v-avatar rounded="0" size="48" color="surface-variant" class="mr-3 flex-shrink-0">
+          <v-avatar rounded="0" size="56" color="surface-variant" class="mr-3 flex-shrink-0">
             <v-img
               v-if="item.thumbnail"
               :src="item.thumbnail"
               :alt="item.name"
             />
-            <v-icon v-else size="28">mdi-gamepad-variant-outline</v-icon>
+            <v-icon v-else size="32">mdi-gamepad-variant-outline</v-icon>
           </v-avatar>
         </template>
 


### PR DESCRIPTION
## Summary

- Moves action buttons out of the `v-list-item` `#append` slot (which compressed the title to almost nothing on narrow viewports) and into the content area below title/subtitle using the `event-actions` pattern — consistent with how the collection list handles its actions
- Aligns avatar size (56px), fallback icon size (32px), title-wrap fix, and hover style with the collection `game-item` pattern
- Switches the BGG link to `color="accent" variant="text"` per icon/external-link conventions in the design system

## Test plan

- [ ] Search for a game on mobile — title and year are fully readable, buttons appear below on their own row
- [ ] "Add" button adds the game and returns to collection view
- [ ] "BGG" link opens the game page in a new tab
- [ ] Already-in-collection items show the "Add" button as disabled
- [ ] Desktop layout still looks reasonable (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjJzyLunWumdefvqeVTXuV)_