### PR TITLE
feat: Facebook data-deletion callback + /data-deletion page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,12 +73,17 @@ Check for: chip/text overlap, truncation, contrast issues, unintentional wrappin
 | `index.vue`          | `/`               | none                                                                                                                                                              |
 | `privacy.vue`        | `/privacy`        | none — static privacy policy (public, no auth)                                                                                                                    |
 | `terms.vue`          | `/terms`          | none — static terms of service (public, no auth)                                                                                                                  |
+| `data-deletion.vue`  | `/data-deletion`  | none — data-deletion info + status page (public, no auth); echoes a `?code` hex confirmation                                                                      |
 
-`/privacy` and `/terms` are public: they're whitelisted alongside `index`/`signin` in `middleware/auth.global.ts`, and linked from the footer in `layouts/default.vue`.
+`/privacy`, `/terms` and `/data-deletion` are public: they're whitelisted alongside `index`/`signin` in `middleware/auth.global.ts`, and linked from the footer (`/privacy`, `/terms`) / the privacy policy (`/data-deletion`).
 
 ### Privacy / cookie consent
 
 Analytics is **opt-in**. `composables/useCookieConsent.ts` holds the consent state (`'granted' | 'denied' | null`, persisted in `localStorage` under `bgc-cookie-consent`, shared via `useState`). `components/CookieConsent.vue` is the bottom banner (mounted in `layouts/default.vue`); the footer's "Cookie settings" button calls `reopen()` to re-prompt. `plugins/01-firebase.client.ts` does not import `firebase/analytics` until consent is `'granted'`, so no analytics cookies/gtag load otherwise. App Check/reCAPTCHA and the Firebase Auth session are strictly-necessary and always on (disclosed in the policy). When changing what data is collected or which processors are used, update `pages/privacy.vue`.
+
+### Data deletion (Facebook + manual)
+
+`functions/src/index.ts` exports `facebookDataDeletion` (an `onRequest` HTTP function), Facebook's required data-deletion callback for Facebook Login. It verifies the `signed_request` HMAC with the `FACEBOOK_APP_SECRET` secret, maps the Facebook app-scoped user id to the Firebase account via `getUserByProviderUid('facebook.com', …)`, runs `deleteUserData(uid)` (a single multi-path RTDB update that removes the user's own subtrees plus the references others hold — reverse friend links, guest entries, pending requests, blocks — and deletes gatherings they host), then deletes the auth account and returns `{ url, confirmation_code }`. The `url` points at `/data-deletion?code=…`; `pages/data-deletion.vue` echoes the hex code and explains manual deletion paths. One-time setup: `firebase functions:secrets:set FACEBOOK_APP_SECRET` (the deploy needs it to exist), then set the function URL as the Facebook app's "Data Deletion Request URL". `deleteUserData` is also the natural home for any future in-app "delete my account" button.
 
 ### Key files
 
@@ -489,7 +494,7 @@ gcloud projects add-iam-policy-binding board-game-calendar-3ae94 \
   --role="roles/eventarc.eventReceiver"
 ```
 
-Secret access (`BGG_API_KEY`, `RESEND_API_KEY`) is auto-granted to the runtime SA at deploy time; this works in CD because the `github-action-…` deployer SA has `secretmanager.admin` and project-level `iam.serviceAccountUser` (so it can grant secrets and `actAs` the runtime SA). Each trigger also pins `instance: 'board-game-calendar-3ae94-default-rtdb'` so the RTDB instance is unambiguous.
+Secret access (`BGG_API_KEY`, `RESEND_API_KEY`, `FACEBOOK_APP_SECRET`) is auto-granted to the runtime SA at deploy time; this works in CD because the `github-action-…` deployer SA has `secretmanager.admin` and project-level `iam.serviceAccountUser` (so it can grant secrets and `actAs` the runtime SA). **Each secret must exist in Secret Manager before a deploy that references it** — a function declaring `secrets: [FACEBOOK_APP_SECRET]` fails to deploy if `FACEBOOK_APP_SECRET` is unset, so run `firebase functions:secrets:set FACEBOOK_APP_SECRET` before merging the data-deletion function. Each trigger also pins `instance: 'board-game-calendar-3ae94-default-rtdb'` so the RTDB instance is unambiguous.
 
 ### Cloud Functions dependencies — no lockfile, pin exact (important)
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,5 @@
 import { setGlobalOptions } from 'firebase-functions'
-import { onCall, HttpsError } from 'firebase-functions/v2/https'
+import { onCall, HttpsError, onRequest } from 'firebase-functions/v2/https'
 import {
   onValueCreated,
   onValueUpdated,
@@ -11,11 +11,13 @@ import { getAuth } from 'firebase-admin/auth'
 import { getDatabase } from 'firebase-admin/database'
 import { parseString } from 'xml2js'
 import { promisify } from 'util'
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto'
 
 initializeApp()
 
 const BGG_API_KEY = defineSecret('BGG_API_KEY')
 const RESEND_API_KEY = defineSecret('RESEND_API_KEY')
+const FACEBOOK_APP_SECRET = defineSecret('FACEBOOK_APP_SECRET')
 
 const parseXml = promisify(parseString)
 
@@ -567,5 +569,190 @@ ${calendarLinkHtml(calEvent)}`
     await Promise.all(
       emails.map((email) => sendEmail(email, subject, html, attachments))
     )
+  }
+)
+
+// --- Facebook data deletion ---------------------------------------------------
+//
+// Facebook requires a data-deletion callback for apps that use Facebook Login.
+// When a user removes the app (or requests deletion) Facebook POSTs a
+// `signed_request` here. We verify it with the app secret, map the Facebook
+// app-scoped user id to the Firebase account that linked it, erase that
+// account's data, and return the JSON Facebook expects: a status URL + a
+// confirmation code.
+//
+// SETUP (one-time, before merging/deploying — the deploy needs the secret):
+//   1. Set the secret to your Facebook App Secret (Facebook App Dashboard →
+//      Settings → Basic → App Secret):
+//        firebase functions:secrets:set FACEBOOK_APP_SECRET
+//   2. After deploy, paste the function URL into the Facebook App Dashboard →
+//      Settings → Basic → "Data Deletion Request URL":
+//        https://us-central1-board-game-calendar-3ae94.cloudfunctions.net/facebookDataDeletion
+//   (Prefer no automation? Use the "Data Deletion Instructions URL" field with
+//    https://bgc.jasonsuttles.dev/data-deletion instead and skip the secret —
+//    deletion then happens by email request rather than automatically.)
+
+const FACEBOOK_PROVIDER_ID = 'facebook.com'
+
+// Verify Facebook's signed_request (`<sig>.<payload>`, both base64url) and
+// return the Facebook user id, or null if missing / forged / malformed.
+function parseSignedRequest(
+  signedRequest: string,
+  appSecret: string
+): string | null {
+  const parts = signedRequest.split('.')
+  if (parts.length !== 2) return null
+  const [encodedSig, encodedPayload] = parts
+
+  const sig = Buffer.from(encodedSig, 'base64url')
+  const expected = createHmac('sha256', appSecret)
+    .update(encodedPayload)
+    .digest()
+  if (sig.length !== expected.length || !timingSafeEqual(sig, expected)) {
+    return null
+  }
+
+  try {
+    const data = JSON.parse(
+      Buffer.from(encodedPayload, 'base64url').toString('utf8')
+    ) as { user_id?: string; algorithm?: string }
+    if (data.algorithm && data.algorithm.toUpperCase() !== 'HMAC-SHA256') {
+      return null
+    }
+    return typeof data.user_id === 'string' ? data.user_id : null
+  } catch {
+    return null
+  }
+}
+
+// Erase everything we hold for a user: their own subtrees plus the references
+// other members hold to them (reverse friend links, guest entries, pending
+// requests, blocks). Hosted gatherings are removed entirely. Applied as one
+// multi-path update; the caller then deletes the auth account.
+async function deleteUserData(uid: string): Promise<void> {
+  const db = getDatabase()
+  const updates: Record<string, null> = {}
+
+  // Reverse friend references on each friend's own list.
+  const friendsSnap = await db.ref(`users/${uid}/friends`).get()
+  const friends = (friendsSnap.val() as Record<string, unknown> | null) ?? {}
+  for (const friendId of Object.keys(friends)) {
+    updates[`users/${friendId}/friends/${uid}`] = null
+  }
+
+  // Walk the user's gathering index (avoids scanning every gathering).
+  const ugSnap = await db.ref(`userGatherings/${uid}`).get()
+  const userGatherings = (ugSnap.val() as Record<string, unknown> | null) ?? {}
+  for (const gid of Object.keys(userGatherings)) {
+    const gSnap = await db.ref(`gatherings/${gid}`).get()
+    const gathering = gSnap.val() as Record<string, unknown> | null
+    if (!gathering) continue
+    if (gathering.host === uid) {
+      // Host is leaving: delete the gathering and each guest's index entry. The
+      // user's own index entry is covered by the userGatherings/${uid} delete
+      // below, so skip it here or the update paths would nest illegally.
+      updates[`gatherings/${gid}`] = null
+      const guests = (gathering.guests as Record<string, unknown> | null) ?? {}
+      for (const guestUid of Object.keys(guests)) {
+        if (guestUid !== uid) {
+          updates[`userGatherings/${guestUid}/${gid}`] = null
+        }
+      }
+    } else {
+      // Guest is leaving: just drop them from the guest list.
+      updates[`gatherings/${gid}/guests/${uid}`] = null
+    }
+  }
+
+  // Friend requests: incoming (whole subtree) + any outgoing references.
+  updates[`friendRequests/${uid}`] = null
+  const frSnap = await db.ref('friendRequests').get()
+  const allRequests =
+    (frSnap.val() as Record<string, Record<string, unknown>> | null) ?? {}
+  for (const [toUid, fromMap] of Object.entries(allRequests)) {
+    if (toUid !== uid && fromMap && uid in fromMap) {
+      updates[`friendRequests/${toUid}/${uid}`] = null
+    }
+  }
+
+  // Blocks: owned by the user (whole subtree) + where others blocked them.
+  updates[`blocked/${uid}`] = null
+  const blockedSnap = await db.ref('blocked').get()
+  const allBlocked =
+    (blockedSnap.val() as Record<string, Record<string, unknown>> | null) ?? {}
+  for (const [ownerUid, blockedMap] of Object.entries(allBlocked)) {
+    if (ownerUid !== uid && blockedMap && uid in blockedMap) {
+      updates[`blocked/${ownerUid}/${uid}`] = null
+    }
+  }
+
+  // The user's own data.
+  updates[`profiles/${uid}`] = null
+  updates[`users/${uid}`] = null
+  updates[`userGatherings/${uid}`] = null
+
+  await db.ref().update(updates)
+}
+
+export const facebookDataDeletion = onRequest(
+  { secrets: [FACEBOOK_APP_SECRET] },
+  async (req, res) => {
+    if (req.method !== 'POST') {
+      res.status(405).send('Method Not Allowed')
+      return
+    }
+
+    const signedRequest = (
+      req.body as { signed_request?: unknown } | undefined
+    )?.signed_request
+    if (typeof signedRequest !== 'string' || !signedRequest) {
+      res.status(400).json({ error: 'Missing signed_request' })
+      return
+    }
+
+    const facebookUserId = parseSignedRequest(
+      signedRequest,
+      FACEBOOK_APP_SECRET.value()
+    )
+    if (!facebookUserId) {
+      res.status(400).json({ error: 'Invalid signed_request' })
+      return
+    }
+
+    const code = randomBytes(8).toString('hex')
+
+    try {
+      const userRecord = await getAuth().getUserByProviderUid(
+        FACEBOOK_PROVIDER_ID,
+        facebookUserId
+      )
+      await deleteUserData(userRecord.uid)
+      await getAuth().deleteUser(userRecord.uid)
+      console.log(
+        `Data deletion ${code}: erased user ${userRecord.uid} (fb ${facebookUserId})`
+      )
+    } catch (err) {
+      // No linked account means nothing to delete — still a success from
+      // Facebook's perspective. Other errors are logged, but we still return a
+      // 200 with the code so Facebook records the request; the status page and
+      // email contact cover any follow-up.
+      if ((err as { code?: string })?.code === 'auth/user-not-found') {
+        console.log(
+          `Data deletion ${code}: no account linked to fb ${facebookUserId}`
+        )
+      } else {
+        console.error(`Data deletion ${code} failed:`, err)
+      }
+    }
+
+    // Record the request so the status URL has something to confirm against.
+    await getDatabase()
+      .ref(`dataDeletionRequests/${code}`)
+      .set({ completedAt: Date.now() })
+
+    res.status(200).json({
+      url: `${APP_URL}/data-deletion?code=${code}`,
+      confirmation_code: code,
+    })
   }
 )

--- a/helpers/names.ts
+++ b/helpers/names.ts
@@ -8,4 +8,5 @@ export default {
   newGathering: 'gatherings-new',
   privacy: 'privacy',
   terms: 'terms',
+  dataDeletion: 'data-deletion',
 }

--- a/helpers/routes.ts
+++ b/helpers/routes.ts
@@ -8,4 +8,5 @@ export default {
   profile: '/profile',
   privacy: '/privacy',
   terms: '/terms',
+  dataDeletion: '/data-deletion',
 }

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -10,9 +10,13 @@ export default defineNuxtRouteMiddleware((to) => {
     }
   } else if (
     to.name &&
-    ![names.index, names.signIn, names.privacy, names.terms].includes(
-      to.name as string
-    )
+    ![
+      names.index,
+      names.signIn,
+      names.privacy,
+      names.terms,
+      names.dataDeletion,
+    ].includes(to.name as string)
   ) {
     // Preserve the intended destination (incl. query, e.g. email RSVP
     // deep-links) so sign-in can return the user there.

--- a/pages/data-deletion.vue
+++ b/pages/data-deletion.vue
@@ -1,0 +1,147 @@
+<template>
+  <v-row justify="center">
+    <v-col cols="12" sm="11" md="9" lg="7">
+      <v-card>
+        <v-card-title class="page-card-title">
+          <div class="d-flex align-center">
+            <v-icon color="primary" class="mr-3 flex-shrink-0"
+              >mdi-account-remove-outline</v-icon
+            >
+            <h1 class="page-title">Data deletion</h1>
+          </div>
+        </v-card-title>
+        <v-divider />
+        <v-card-text class="pa-6 legal">
+          <div v-if="code" class="confirmation">
+            <p>
+              Your data deletion request has been received. We've erased the
+              personal data associated with the account linked to it.
+            </p>
+            <p class="confirmation-code">
+              Reference code: <strong>{{ code }}</strong>
+            </p>
+            <p>
+              Keep this code if you'd like to ask us about the request. Questions?
+              Email
+              <a href="mailto:privacy@jasonsuttles.dev"
+                >privacy@jasonsuttles.dev</a
+              >.
+            </p>
+          </div>
+
+          <h2 class="legal-h2">How to delete your account and data</h2>
+          <p>
+            You can have everything we hold about you removed at any time, in any
+            of these ways:
+          </p>
+          <ul>
+            <li>
+              <strong>In the app</strong> — sign in and clear your profile, then
+              email us (below) to remove the account itself.
+            </li>
+            <li>
+              <strong>By email</strong> — write to
+              <a href="mailto:privacy@jasonsuttles.dev"
+                >privacy@jasonsuttles.dev</a
+              >
+              from the address on your account and we'll delete it within a
+              reasonable time.
+            </li>
+            <li>
+              <strong>Through Facebook</strong> — if you signed in with Facebook,
+              removing Board Game Calendar from your Facebook
+              <a
+                href="https://www.facebook.com/settings?tab=applications"
+                target="_blank"
+                rel="noopener noreferrer"
+                >app settings</a
+              >
+              triggers an automatic deletion request, and Facebook shows you a
+              confirmation code that links back to this page.
+            </li>
+          </ul>
+
+          <h2 class="legal-h2">What gets deleted</h2>
+          <p>
+            We remove your profile, your game collection and notes, your friends
+            and friend requests, and the gatherings you host. Gatherings you were
+            only invited to have your entry removed. Backups and security logs may
+            persist briefly before rotating out.
+          </p>
+
+          <p class="mt-6">
+            <NuxtLink :to="routes.privacy" class="legal-inline-link"
+              >← Back to the privacy policy</NuxtLink
+            >
+          </p>
+        </v-card-text>
+      </v-card>
+    </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import routes from '~/helpers/routes'
+
+useHead({ title: 'Data deletion' })
+
+const route = useRoute()
+const code = computed(() => {
+  const c = route.query.code
+  const value = Array.isArray(c) ? c[0] : c
+  // Only echo a plausible confirmation code (hex), never arbitrary query text.
+  return typeof value === 'string' && /^[a-f0-9]{8,32}$/.test(value)
+    ? value
+    : ''
+})
+</script>
+
+<style scoped>
+.legal {
+  font-family: 'Lora', Georgia, serif;
+  font-size: 0.96rem;
+  line-height: 1.7;
+  color: #e8d4a8;
+}
+
+.legal p {
+  margin-bottom: 1rem;
+}
+
+.legal ul {
+  margin: 0 0 1rem 1.1rem;
+  padding: 0;
+}
+
+.legal li {
+  margin-bottom: 0.5rem;
+}
+
+.legal-h2 {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #c8860a;
+  margin: 1.6rem 0 0.6rem;
+}
+
+.legal a,
+.legal-inline-link {
+  color: #c0a870;
+  text-decoration: underline;
+}
+
+.confirmation {
+  border: 1px solid rgba(85, 184, 85, 0.4);
+  background: rgba(85, 184, 85, 0.08);
+  border-radius: 10px;
+  padding: 16px 20px;
+  margin-bottom: 0.5rem;
+}
+
+.confirmation-code {
+  font-family: 'Lora', Georgia, serif;
+  letter-spacing: 0.02em;
+}
+</style>

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -161,7 +161,11 @@
             edit or clear your profile, delete gatherings, unfriend, and decline
             analytics. To request access or full account deletion, email
             <a href="mailto:privacy@jasonsuttles.dev">privacy@jasonsuttles.dev</a>
-            and we'll action it within a reasonable time.
+            and we'll action it within a reasonable time. See
+            <NuxtLink :to="routes.dataDeletion" class="legal-inline-link"
+              >data deletion</NuxtLink
+            >
+            for how account deletion works, including via Facebook.
           </p>
 
           <h2 class="legal-h2">Retention</h2>


### PR DESCRIPTION
## What

The follow-up flagged in the consent PR: Facebook Login's app review requires a data-deletion path. This adds the **automated callback** plus a public **info/status page**.

- **`functions/src/index.ts` → `facebookDataDeletion`** (`onRequest`): verifies Facebook's `signed_request` HMAC with the `FACEBOOK_APP_SECRET` secret, maps the Facebook app-scoped user id to the Firebase account via `getUserByProviderUid('facebook.com', …)`, runs `deleteUserData(uid)`, deletes the auth account, and returns `{ url, confirmation_code }`.
- **`deleteUserData(uid)`**: one multi-path RTDB update that removes the user's own subtrees (`profiles`, `users`, `userGatherings`) plus the references others hold — reverse friend links, guest entries, pending friend requests, blocks — and deletes any gatherings they host. Walks the `userGatherings` index rather than scanning every gathering. (Also the natural home for a future in-app "delete my account" button.)
- **`pages/data-deletion.vue`**: public page that echoes a validated hex `?code` confirmation and documents the manual + Facebook deletion paths. Route whitelisted in `middleware/auth.global.ts`; linked from the privacy policy.

## ⚠️ Required setup before merging

The deploy will **fail** if the secret doesn't exist, because the function declares `secrets: [FACEBOOK_APP_SECRET]`. So, before marking this ready / merging:

1. **Set the secret** to your Facebook App Secret (Facebook App Dashboard → Settings → Basic → *App Secret*):
   ```
   firebase functions:secrets:set FACEBOOK_APP_SECRET
   ```
2. After it deploys (CD does this on merge to `main`), paste the function URL into the Facebook App Dashboard → Settings → Basic → **"Data Deletion Request URL"**:
   ```
   https://us-central1-board-game-calendar-3ae94.cloudfunctions.net/facebookDataDeletion
   ```

**Prefer no automation / no secret?** Skip step 1, drop the `facebookDataDeletion` function, and instead set Facebook's **"Data Deletion Instructions URL"** to `https://bgc.jasonsuttles.dev/data-deletion`. The page already explains how to request deletion by email — that alone satisfies Facebook's requirement. Tell me which way you want and I'll adjust.

## Verification

- The `signed_request` HMAC verification (the security-critical part) was checked with a standalone script: valid tokens return the user id; wrong-secret, tampered-payload, malformed, missing-user_id, and wrong-algorithm inputs all reject. ✅
- Local install of dependencies could not complete in this sandbox, so `yarn lint` / `yarn test` / the functions build were not run locally — **CI runs the full gate** (it builds `functions/`). Please confirm CI is green before merging. I'm watching this PR.

## Notes

- The endpoint is intentionally public (Facebook calls it unauthenticated) — it's protected by the HMAC signature check, not App Check.
- `dataDeletionRequests/{code}` is written by Admin SDK only; RTDB default-deny keeps it unreadable to clients, so no security-rules change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQLJgtFkdb3gFyNe2vuswo)_