### PR TITLE
fix: retry single-recipient emails when Resend send fails

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -278,14 +278,20 @@ function escapeHtml(s: string): string {
 
 type EmailAttachment = { filename: string; content: string } // content: base64
 
-// Sends a single email and logs on failure without rethrowing, so one bad
-// address doesn't cause a function retry that re-sends to everyone else.
+// Sends a single email via Resend. Returns whether it succeeded; logs the
+// response body on failure either way. Callers with a single recipient
+// (friend requests, gathering invites, email invites) should throw on a
+// `false` return so Cloud Functions' built-in retry can recover from a
+// transient Resend error — 2nd-gen event-driven functions retry on a thrown
+// error by default. Callers that loop over multiple recipients (gathering
+// state changes) should NOT rethrow per-recipient failures, since a retry
+// would re-send to everyone, including recipients who already got it.
 async function sendEmail(
   to: string,
   subject: string,
   html: string,
   attachments?: EmailAttachment[]
-): Promise<void> {
+): Promise<boolean> {
   const res = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
@@ -303,7 +309,9 @@ async function sendEmail(
   if (!res.ok) {
     const body = await res.text()
     console.error(`Resend error ${res.status} for ${to}: ${body}`)
+    return false
   }
+  return true
 }
 
 function formatDatetime(iso: string, timezone?: string): string {
@@ -475,7 +483,7 @@ export const onEmailInviteCreated = onValueCreated(
     const gamesHtml = gamesList.length
       ? `<p><strong>Games planned:</strong> ${gamesList.join(', ')}</p>`
       : ''
-    await sendEmail(
+    const sent = await sendEmail(
       email,
       `You're invited to a board game night!`,
       `<p>Hi there,</p>
@@ -487,6 +495,7 @@ ${rsvpButtonsHtml(gatheringId)}
 ${calendarLinkHtml(calEvent)}`,
       [icsAttachment(calEvent)]
     )
+    if (!sent) throw new Error(`Failed to send invite email to ${email}`)
   }
 )
 
@@ -563,13 +572,14 @@ export const onFriendRequest = onValueCreated(
     ])
     if (!toUser.email) return
     const safeName = escapeHtml(fromName)
-    await sendEmail(
+    const sent = await sendEmail(
       toUser.email,
       `${fromName} sent you a friend request`,
       `<p>Hi there,</p>
 <p><strong>${safeName}</strong> has sent you a friend request on Board Game Calendar.</p>
 <p><a href="${APP_URL}/friends">View your friend requests</a></p>`
     )
+    if (!sent) throw new Error(`Failed to send friend request email to ${toUser.email}`)
   }
 )
 
@@ -604,7 +614,7 @@ export const onGatheringInvite = onValueWritten(
       hostName,
       games: gathering.games as { name?: string }[] | undefined,
     }
-    await sendEmail(
+    const sent = await sendEmail(
       guestUser.email,
       `You're invited to a board game night!`,
       `<p>Hi there,</p>
@@ -614,6 +624,7 @@ ${rsvpButtonsHtml(gatheringId)}
 ${calendarLinkHtml(calEvent)}`,
       [icsAttachment(calEvent)]
     )
+    if (!sent) throw new Error(`Failed to send invite email to ${guestUser.email}`)
   }
 )
 


### PR DESCRIPTION
## Summary

Fixes a bug where inviting an email address that doesn't have an account could silently never send the invite email.

`sendEmail()` in `functions/src/index.ts` logged Resend API errors but always resolved successfully (`Promise<void>`), even when the email failed to send. Because 2nd-gen Cloud Functions only retry an event-driven trigger when it throws, `onEmailInviteCreated` (and `onFriendRequest`, `onGatheringInvite`) would complete "successfully" on a transient Resend failure and never get retried — the invited person never received an email.

- `sendEmail()` now returns `Promise<boolean>` indicating whether the Resend call succeeded, instead of swallowing the failure silently.
- `onEmailInviteCreated`, `onFriendRequest`, and `onGatheringInvite` (all single-recipient) now throw when `sendEmail` returns `false`, so Cloud Functions' built-in retry can recover from a transient failure.
- `onGatheringStateChange` (multi-recipient, loops over guests) is left unchanged — it still must not rethrow per-recipient failures, since a retry there would re-send to every recipient, including guests who already got the email.

## Test plan

- [ ] `yarn lint` (could not run locally — outbound network to the package registry is blocked in this environment; diff was manually reviewed for correctness and style consistency)
- [ ] `yarn workspace functions run build` (same network limitation)
- [ ] Manually verify: create a gathering, add an email invite for an address with no account, confirm the invite email arrives; simulate a Resend failure (e.g. temporarily invalid API key) and confirm the function now retries instead of silently dropping the email


---
_Generated by [Claude Code](https://claude.ai/code/session_012HrCuhj5bs1bWPsHg2jsiv)_