### PR TITLE
fix(functions): sanitize gatheringId before it reaches email HTML

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -427,7 +427,7 @@ function buildIcs(event: CalendarEvent): string {
     'CALSCALE:GREGORIAN',
     'METHOD:PUBLISH',
     'BEGIN:VEVENT',
-    `UID:${event.gatheringId}@bgc.jasonsuttles.dev`,
+    `UID:${escapeIcs(event.gatheringId)}@bgc.jasonsuttles.dev`,
     `DTSTAMP:${toIcsUtc(new Date())}`,
     `DTSTART:${toIcsUtc(new Date(event.datetime))}`,
     `DTEND:${toIcsUtc(eventEnd(event.datetime))}`,
@@ -455,8 +455,9 @@ function calendarLinkHtml(event: CalendarEvent): string {
 // Accept / Decline buttons that deep-link into the app (the user signs in if
 // needed, then the RSVP is applied on the calendar page).
 function rsvpButtonsHtml(gatheringId: string): string {
-  const accept = `${APP_URL}/calendar?id=${gatheringId}&respond=accepted`
-  const decline = `${APP_URL}/calendar?id=${gatheringId}&respond=declined`
+  const id = encodeURIComponent(gatheringId)
+  const accept = `${APP_URL}/calendar?id=${id}&respond=accepted`
+  const decline = `${APP_URL}/calendar?id=${id}&respond=declined`
   return `<p>
   <a href="${accept}" style="display:inline-block;padding:10px 18px;margin-right:8px;background:#55B855;color:#100A04;text-decoration:none;border-radius:8px;font-weight:600;">Accept</a>
   <a href="${decline}" style="display:inline-block;padding:10px 18px;background:#E05252;color:#100A04;text-decoration:none;border-radius:8px;font-weight:600;">Decline</a>


### PR DESCRIPTION
## Summary

- `database.rules.json` constrains a gathering's *value* shape but never the `gatherings/{id}` *key* itself. RTDB keys can contain characters like `"`, `<`, `>`, `&`, and spaces (everything except `. # $ [ ] /` and control characters), so an authenticated client can bypass the app's UI (which always uses `push()`) and `set()` a gathering directly under an attacker-chosen key.
- That key (`gatheringId`) was interpolated **unescaped** into the RSVP Accept/Decline link hrefs in transactional emails (`rsvpButtonsHtml`) and into the ICS `UID` field (`buildIcs`) — unlike every other user-influenced field in these templates (`location`, `notes`, names, game titles), which already goes through `escapeHtml`/`escapeIcs`.
- Exploit: an attacker creates a gathering under a crafted key (e.g. containing `"><a href="https://evil.example">`) and adds an email invite to any address (email invites require no prior relationship). The resulting invite email — sent from the app's trusted sending domain — contains attacker-controlled markup, a solid phishing primitive.
- Fix: `encodeURIComponent(gatheringId)` before it's placed in the accept/decline URLs (also correct on the merits — it's a URL query value), and `escapeIcs(event.gatheringId)` for the ICS `UID`, matching how the other fields are already handled.

A rules-level fix (constraining `$gatheringId` to Firebase's push-ID shape) would close this at the source too, but the existing `test/rules/database.rules.spec.ts` suite seeds gatherings with plain keys like `g1`/`g2` throughout hundreds of assertions, so that change would ripple across the whole test file. Scoped this fix to the actual injection point instead.

## Test plan

- [x] `yarn workspace functions run build` — typechecks clean
- [x] `yarn lint` — clean
- [ ] Manual: trigger `onGatheringEmailInvite` / `onGatheringInvite` against a gathering with a crafted key and confirm the emailed links render as plain encoded text, not markup

Found via an adversarial security review of this repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZ2HYv1SPoukVNYgJTNRSX)_