### PR TITLE
fix(functions): purge email invites addressed to a deleted account

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1088,7 +1088,8 @@ function parseSignedRequest(
 
 // Erase everything we hold for a user: their own subtrees plus the references
 // other members hold to them (reverse friend links, guest entries, pending
-// requests, blocks). Hosted gatherings are removed entirely. Applied as one
+// requests, blocks, email invites addressed to them on other hosts'
+// gatherings). Hosted gatherings are removed entirely. Applied as one
 // multi-path update; the caller then deletes the auth account.
 async function deleteUserData(uid: string): Promise<void> {
   const db = getDatabase()
@@ -1144,6 +1145,34 @@ async function deleteUserData(uid: string): Promise<void> {
   for (const [ownerUid, blockedMap] of Object.entries(allBlocked)) {
     if (ownerUid !== uid && blockedMap && uid in blockedMap) {
       updates[`blocked/${ownerUid}/${uid}`] = null
+    }
+  }
+
+  // Email invites addressed to this account's own verified email, sitting on
+  // gatherings hosted by *other* users, also need to go — otherwise the
+  // address (and its emailInviteIndex entry) outlives the account it was
+  // tied to. Mirrors the lookup listMyEmailInvites does, minus the fan-out
+  // cap (this runs once per deletion, not per page load).
+  const email = (await getAuth().getUser(uid)).email?.toLowerCase()
+  if (email) {
+    const emailHash = hashEmail(email)
+    const indexSnap = await db.ref(`emailInviteIndex/${emailHash}`).get()
+    const invitedGatheringIds = Object.keys(
+      (indexSnap.val() as Record<string, boolean> | null) ?? {}
+    )
+    for (const gid of invitedGatheringIds) {
+      if (updates[`gatherings/${gid}`] === null) continue // whole gathering already going away above
+      const emailInvitesSnap = await db
+        .ref(`gatherings/${gid}/emailInvites`)
+        .get()
+      const emailInvites =
+        (emailInvitesSnap.val() as Record<string, string> | null) ?? {}
+      for (const [inviteId, inviteEmail] of Object.entries(emailInvites)) {
+        if (inviteEmail.toLowerCase() === email) {
+          updates[`gatherings/${gid}/emailInvites/${inviteId}`] = null
+        }
+      }
+      updates[`emailInviteIndex/${emailHash}/${gid}`] = null
     }
   }
 


### PR DESCRIPTION
## Summary

- `deleteUserData(uid)` (the Facebook-mandated + future in-app erasure path) removes the deleted account's own subtrees and cleans up reverse references other users hold on them (friend lists, friend requests, blocks, gathering guest entries) — but it never looked up `emailInviteIndex/{hash(email)}` to find and remove pending email invites addressed to that account's *own* email sitting on gatherings hosted by *other* users.
- Concretely: host A email-invites `victim@example.com` (email invites need no prior relationship). The victim later signs up with that email and requests account deletion. `deleteUserData` erased their own data but left their plaintext email sitting in host A's `gatherings/{id}/emailInvites` and in `emailInviteIndex` indefinitely — a real gap in the one function whose entire purpose is legal data erasure.
- Fix mirrors the lookup `listMyEmailInvites` already does (read `emailInviteIndex/{hash(email)}` for the account's verified email, look up each referenced gathering's `emailInvites`, remove any entry matching the address) and folds the removals into the same multi-path `update()` as the rest of the deletion, so it's atomic with everything else `deleteUserData` already does. Skips gatherings the deleted account itself hosts (already fully removed a few lines above, so a nested path there would conflict in the multi-path update).

## Test plan

- [x] `yarn workspace functions run build` — typechecks clean
- [x] `yarn lint` — clean
- [ ] Manual: create gathering A with an email invite to user B's address, delete B's account via the data-deletion flow, confirm the `emailInvites` entry and `emailInviteIndex` entry are both gone from gathering A

Found via an adversarial security review of this repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZ2HYv1SPoukVNYgJTNRSX)_